### PR TITLE
Structured errors

### DIFF
--- a/app/src/main/java/com/nike/dooit/api/DooitAPIError.java
+++ b/app/src/main/java/com/nike/dooit/api/DooitAPIError.java
@@ -2,6 +2,9 @@ package com.nike.dooit.api;
 
 import com.nike.dooit.api.responses.ErrorResponse;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import retrofit2.adapter.rxjava.HttpException;
 
 /**
@@ -25,21 +28,13 @@ public class DooitAPIError extends Throwable {
     }
 
     private boolean hasError() {
-        return getErrorResponse() != null &&
-                getErrorResponse().error != null &&
-                getErrorResponse().error.message != null;
+        return getErrorResponse().hasErrors();
     }
 
-    public String getErrorMessage() {
+    public List<String> getErrorMessages() {
         if (hasError())
-            return getErrorResponse().error.message;
-        return "";
-    }
-
-    public String getErrorCode() {
-        if (hasError())
-            return getErrorResponse().error.code;
-        return "";
+            return getErrorResponse().getErrors();
+        return new ArrayList();
     }
 
     @Override

--- a/app/src/main/java/com/nike/dooit/api/responses/ErrorResponse.java
+++ b/app/src/main/java/com/nike/dooit/api/responses/ErrorResponse.java
@@ -22,8 +22,6 @@ public class ErrorResponse {
     @SerializedName("field_errors")
     private Map<String, List<String>> fieldErrors;
 
-    public ErrorBody error;
-
     public int getStatus() {
         return status;
     }
@@ -32,16 +30,15 @@ public class ErrorResponse {
         return errors;
     }
 
+    public boolean hasErrors() {
+        return errors != null && !errors.isEmpty();
+    }
+
     public Map<String, List<String>> getRelErrors() {
         return relErrors;
     }
 
     public Map<String, List<String>> getFieldErrors() {
         return fieldErrors;
-    }
-
-    public static class ErrorBody {
-        public String code;
-        public String message;
     }
 }

--- a/app/src/main/java/com/nike/dooit/api/responses/ErrorResponse.java
+++ b/app/src/main/java/com/nike/dooit/api/responses/ErrorResponse.java
@@ -1,13 +1,44 @@
 package com.nike.dooit.api.responses;
 
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+import java.util.Map;
+
 /**
  * Created by herman on 2016/11/05.
  */
 
 public class ErrorResponse {
 
-    public String status;
+    @SerializedName("status_code")
+    private int status;
+
+    private List<String> errors;
+
+    @SerializedName("rel_errors")
+    private Map<String, List<String>> relErrors;
+
+    @SerializedName("field_errors")
+    private Map<String, List<String>> fieldErrors;
+
     public ErrorBody error;
+
+    public int getStatus() {
+        return status;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public Map<String, List<String>> getRelErrors() {
+        return relErrors;
+    }
+
+    public Map<String, List<String>> getFieldErrors() {
+        return fieldErrors;
+    }
 
     public static class ErrorBody {
         public String code;

--- a/app/src/main/java/com/nike/dooit/views/main/fragments/challenge/fragments/ChallengeFreeformFragment.java
+++ b/app/src/main/java/com/nike/dooit/views/main/fragments/challenge/fragments/ChallengeFreeformFragment.java
@@ -93,7 +93,7 @@ public class ChallengeFreeformFragment extends Fragment {
         challengeManager.fetchParticipantFreeformAnswer(challenge.getId(), new DooitErrorHandler() {
             @Override
             public void onError(DooitAPIError error) {
-                if ("404".equals(error.getErrorResponse().status)) {
+                if (error.getErrorResponse().getStatus() == 404) {
                     Log.d(TAG, "No entry submitted yet");
                 } else {
                     Log.d(TAG, "Could not fetch challenge entry");

--- a/app/src/main/java/com/nike/dooit/views/onboarding/LoginActivity.java
+++ b/app/src/main/java/com/nike/dooit/views/onboarding/LoginActivity.java
@@ -68,8 +68,10 @@ public class LoginActivity extends DooitActivity {
         authenticationManager.login(name.getText().toString(), password.getText().toString(), new DooitErrorHandler() {
             @Override
             public void onError(DooitAPIError error) {
-
-                Snackbar.make(buttonLogin, R.string.invalid_credentials, Snackbar.LENGTH_SHORT).show();
+                for (String msg : error.getErrorResponse().getErrors()) {
+                    Snackbar.make(buttonLogin, msg, Snackbar.LENGTH_SHORT).show();
+                }
+//                Snackbar.make(buttonLogin, R.string.invalid_credentials, Snackbar.LENGTH_SHORT).show();
             }
         }).subscribe(new Action1<AuthenticationResponse>() {
             @Override

--- a/app/src/main/java/com/nike/dooit/views/onboarding/LoginActivity.java
+++ b/app/src/main/java/com/nike/dooit/views/onboarding/LoginActivity.java
@@ -68,10 +68,8 @@ public class LoginActivity extends DooitActivity {
         authenticationManager.login(name.getText().toString(), password.getText().toString(), new DooitErrorHandler() {
             @Override
             public void onError(DooitAPIError error) {
-                for (String msg : error.getErrorResponse().getErrors()) {
+                for (String msg : error.getErrorResponse().getErrors())
                     Snackbar.make(buttonLogin, msg, Snackbar.LENGTH_SHORT).show();
-                }
-//                Snackbar.make(buttonLogin, R.string.invalid_credentials, Snackbar.LENGTH_SHORT).show();
             }
         }).subscribe(new Action1<AuthenticationResponse>() {
             @Override

--- a/app/src/main/java/com/nike/dooit/views/onboarding/ProfileImageActivity.java
+++ b/app/src/main/java/com/nike/dooit/views/onboarding/ProfileImageActivity.java
@@ -8,6 +8,8 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.MediaStore;
+import android.support.design.widget.Snackbar;
+import android.widget.Button;
 import android.widget.Toast;
 
 import com.facebook.drawee.view.SimpleDraweeView;
@@ -44,6 +46,8 @@ public class ProfileImageActivity extends DooitActivity {
     @BindView(R.id.activity_profile_image_profile_image)
     SimpleDraweeView simpleDraweeView;
 
+    @BindView(R.id.activity_profile_image_next_button)
+    Button nextButton;
 
     @Inject
     AuthenticationManager authenticationManager;
@@ -104,10 +108,12 @@ public class ProfileImageActivity extends DooitActivity {
             return;
         }
         User user = persisted.getCurrentUser();
-        fileUploadManager.upload(user.getId(), getIntent().getStringExtra(INTENT_MIME_TYPE), new File(((Uri) getIntent().getParcelableExtra(INTENT_IMAGE_URI)).toString()), new DooitErrorHandler() {
+        fileUploadManager.upload(user.getId(), getIntent().getStringExtra(INTENT_MIME_TYPE),
+                new File(((Uri) getIntent().getParcelableExtra(INTENT_IMAGE_URI)).toString()), new DooitErrorHandler() {
             @Override
             public void onError(DooitAPIError error) {
-                Toast.makeText(ProfileImageActivity.this, "Unable to upload Image", Toast.LENGTH_SHORT).show();
+                for (String msg : error.getErrorMessages())
+                    Snackbar.make(nextButton, msg, Snackbar.LENGTH_SHORT).show();
             }
         }).subscribe(new Action1<EmptyResponse>() {
             @Override

--- a/app/src/main/java/com/nike/dooit/views/onboarding/RegistrationActivity.java
+++ b/app/src/main/java/com/nike/dooit/views/onboarding/RegistrationActivity.java
@@ -3,15 +3,16 @@ package com.nike.dooit.views.onboarding;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v4.content.res.ResourcesCompat;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.RadioGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.nike.dooit.DooitApplication;
 import com.nike.dooit.R;
@@ -20,9 +21,9 @@ import com.nike.dooit.api.DooitErrorHandler;
 import com.nike.dooit.api.managers.AuthenticationManager;
 import com.nike.dooit.api.responses.AuthenticationResponse;
 import com.nike.dooit.api.responses.OnboardingResponse;
+import com.nike.dooit.helpers.Persisted;
 import com.nike.dooit.models.Profile;
 import com.nike.dooit.models.User;
-import com.nike.dooit.helpers.Persisted;
 import com.nike.dooit.views.DooitActivity;
 import com.nike.dooit.views.helpers.activity.DooitActivityBuilder;
 
@@ -68,6 +69,9 @@ public class RegistrationActivity extends DooitActivity {
     @BindView(R.id.activity_registration_password_example_text_edit)
     TextView passwordHint;
 
+    @BindView(R.id.activity_registration_register_button)
+    Button registerButton;
+
 
     @Inject
     AuthenticationManager authenticationManager;
@@ -112,8 +116,8 @@ public class RegistrationActivity extends DooitActivity {
         authenticationManager.onboard(getUser(), new DooitErrorHandler() {
             @Override
             public void onError(DooitAPIError error) {
-                Toast.makeText(RegistrationActivity.this, "Unable to register", Toast.LENGTH_SHORT).show();
-
+                for (String msg : error.getErrorMessages())
+                    Snackbar.make(registerButton, msg, Snackbar.LENGTH_SHORT).show();
             }
         }).subscribe(new Action1<OnboardingResponse>() {
             @Override
@@ -121,7 +125,8 @@ public class RegistrationActivity extends DooitActivity {
                 authenticationManager.login(getUser().getUsername(), getUser().getPassword(), new DooitErrorHandler() {
                     @Override
                     public void onError(DooitAPIError error) {
-                        Toast.makeText(RegistrationActivity.this, "Unable to Log in", Toast.LENGTH_SHORT).show();
+                        for (String msg : error.getErrorMessages())
+                            Snackbar.make(registerButton, msg, Snackbar.LENGTH_SHORT).show();
                     }
                 }).subscribe(new Action1<AuthenticationResponse>() {
                     @Override


### PR DESCRIPTION
Changed errors to support to structured format: https://github.com/praekeltfoundation/gem-bbb-indo-server/pull/40

Example:

```json
{
  "status_code": 400,
  "errors": [
    "Unable to log in with provided credentials."
  ],
  "rel_errors": {
    "profile": [
      "Invalid data. Expected a dictionary, but got str."
    ]
  },
  "field_errors": {
    "password": [
      "This field is required."
    ],
    "username": [
      "This field may not be blank."
    ],
    "profile_mobile": [
      "Phone number must be entered in the format: '+999999999'. Up to 15 digits allowed."
    ],
    "profile_age": [
      "A valid integer is required."
    ]
  }
}
```