### PR TITLE
Challenge persistence

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/GEMIndo.iml" filepath="$PROJECT_DIR$/GEMIndo.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/gem-bbb-indo.iml" filepath="$PROJECT_DIR$/gem-bbb-indo.iml" />
     </modules>
   </component>
 </project>

--- a/app/src/main/java/org/gem/indo/dooit/helpers/DooitSharedPreferences.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/DooitSharedPreferences.java
@@ -12,6 +12,8 @@ import org.gem.indo.dooit.api.serializers.LocalDateSerializer;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Set;
 
 import javax.inject.Singleton;
@@ -75,6 +77,14 @@ public class DooitSharedPreferences {
 
     public <T> T getComplex(String key, Class<T> clazz) {
         return gson.fromJson(getString(key, ""), clazz);
+    }
+
+    public <T> T getComplex(String key, Type type) {
+        try {
+            return gson.fromJson(getString(key, ""), type);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public void setString(String key, String value) {

--- a/app/src/main/java/org/gem/indo/dooit/helpers/DooitSharedPreferences.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/DooitSharedPreferences.java
@@ -12,7 +12,6 @@ import org.gem.indo.dooit.api.serializers.LocalDateSerializer;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Set;
 

--- a/app/src/main/java/org/gem/indo/dooit/helpers/DooitSharedPreferences.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/DooitSharedPreferences.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.gem.indo.dooit.api.serializers.ChallengeSerializer;
 import org.gem.indo.dooit.api.serializers.DateTimeSerializer;
 import org.gem.indo.dooit.api.serializers.LocalDateSerializer;
 import org.joda.time.DateTime;
@@ -32,6 +33,7 @@ public class DooitSharedPreferences {
         gson = new GsonBuilder()
                 .registerTypeAdapter(DateTime.class, new DateTimeSerializer())
                 .registerTypeAdapter(LocalDate.class, new LocalDateSerializer())
+                .registerTypeAdapterFactory(ChallengeSerializer.getChallengeAdapterFactory())
                 .create();
     }
 

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
+import com.google.gson.reflect.TypeToken;
 
 import org.gem.indo.dooit.DooitApplication;
 import org.gem.indo.dooit.helpers.bot.ListParameterizedType;
@@ -24,8 +25,10 @@ import org.gem.indo.dooit.models.enums.BotType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.lang.reflect.Type;
 
 import javax.inject.Inject;
 
@@ -181,7 +184,7 @@ public class Persisted {
 
     public Map<Long, QuizChallengeQuestionState> loadQuizChallengeState() {
         MapParameterizedType type = new MapParameterizedType(Long.class, QuizChallengeQuestionState.class);
-        return (Map<Long, QuizChallengeQuestionState>) dooitSharedPreferences.getComplex(QUIZ_STATE, type.getClass());
+        return dooitSharedPreferences.getComplex(QUIZ_STATE, type);
     }
 
     public void saveQuizChallengeIndex(int idx) {
@@ -206,7 +209,11 @@ public class Persisted {
 
     public List<ParticipantAnswer> loadQuizChallengeAnswers() {
         ListParameterizedType type = new ListParameterizedType(ParticipantAnswer.class);
-        return (List<ParticipantAnswer>) dooitSharedPreferences.getComplex(QUIZ_ANSWERS, type.getClass());
+        ParticipantAnswer[] answers = dooitSharedPreferences.getComplex(QUIZ_ANSWERS, ParticipantAnswer[].class);
+        if (answers != null)
+            return new ArrayList<>(Arrays.asList(answers));
+        return new ArrayList<ParticipantAnswer>();
+//        return dooitSharedPreferences.getComplex(QUIZ_ANSWERS, type.getClass());
     }
 
     public void clearQuizChallengeAnswers() {

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
@@ -36,6 +36,7 @@ public class Persisted {
     private static final String TOKEN = "token";
     private static final String USER = "user";
     private static final String CHALLENGE = "challenge";
+    private static final String QUIZ_INDEX = "quiz_index";
     private static final String QUIZ_STATE = "quiz_state";
     private static final String QUIZ_ANSWERS = "quiz_answers";
     private static final String BOT = "bot";
@@ -181,6 +182,18 @@ public class Persisted {
     public Map<Long, QuizChallengeQuestionState> loadQuizChallengeState() {
         MapParameterizedType type = new MapParameterizedType(Long.class, QuizChallengeQuestionState.class);
         return (Map<Long, QuizChallengeQuestionState>) dooitSharedPreferences.getComplex(QUIZ_STATE, type.getClass());
+    }
+
+    public void saveQuizChallengeIndex(int idx) {
+        dooitSharedPreferences.setInteger(QUIZ_INDEX, idx);
+    }
+
+    public int loadQuizChallengeIndex() {
+        return dooitSharedPreferences.getInteger(QUIZ_INDEX, -1);
+    }
+
+    public void clearQuizChallengeIndex() {
+        dooitSharedPreferences.remove(QUIZ_INDEX);
     }
 
     public void clearQuizChallengeState() {

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
@@ -184,18 +184,6 @@ public class Persisted {
         return dooitSharedPreferences.getComplex(QUIZ_STATE, type);
     }
 
-    public void saveQuizChallengeIndex(int idx) {
-        dooitSharedPreferences.setInteger(QUIZ_INDEX, idx);
-    }
-
-    public int loadQuizChallengeIndex() {
-        return dooitSharedPreferences.getInteger(QUIZ_INDEX, -1);
-    }
-
-    public void clearQuizChallengeIndex() {
-        dooitSharedPreferences.remove(QUIZ_INDEX);
-    }
-
     public void clearQuizChallengeState() {
         dooitSharedPreferences.remove(QUIZ_STATE);
     }

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
@@ -8,6 +8,8 @@ import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
 
 import org.gem.indo.dooit.DooitApplication;
+import org.gem.indo.dooit.helpers.bot.ListParameterizedType;
+import org.gem.indo.dooit.helpers.challenge.MapParameterizedType;
 import org.gem.indo.dooit.models.Goal;
 import org.gem.indo.dooit.models.Tip;
 import org.gem.indo.dooit.models.Token;
@@ -16,11 +18,14 @@ import org.gem.indo.dooit.models.bot.Answer;
 import org.gem.indo.dooit.models.bot.BaseBotModel;
 import org.gem.indo.dooit.models.bot.Node;
 import org.gem.indo.dooit.models.challenge.BaseChallenge;
+import org.gem.indo.dooit.models.challenge.ParticipantAnswer;
+import org.gem.indo.dooit.models.challenge.QuizChallengeQuestionState;
 import org.gem.indo.dooit.models.enums.BotType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -31,6 +36,8 @@ public class Persisted {
     private static final String TOKEN = "token";
     private static final String USER = "user";
     private static final String CHALLENGE = "challenge";
+    private static final String QUIZ_STATE = "quiz_state";
+    private static final String QUIZ_ANSWERS = "quiz_answers";
     private static final String BOT = "bot";
     private static final String GOAL = "goal";
     private static final String TIPS = "tips";
@@ -165,6 +172,32 @@ public class Persisted {
 
     public void clearCurrentChallenge() {
         dooitSharedPreferences.remove(CHALLENGE);
+    }
+
+    public void saveQuizChallengeState(Map<Long, QuizChallengeQuestionState> state) {
+        dooitSharedPreferences.setComplex(QUIZ_STATE, state);
+    }
+
+    public Map<Long, QuizChallengeQuestionState> loadQuizChallengeState() {
+        MapParameterizedType type = new MapParameterizedType(Long.class, QuizChallengeQuestionState.class);
+        return (Map<Long, QuizChallengeQuestionState>) dooitSharedPreferences.getComplex(QUIZ_STATE, type.getClass());
+    }
+
+    public void clearQuizChallengeState() {
+        dooitSharedPreferences.remove(QUIZ_STATE);
+    }
+
+    public void saveQuizChallengeAnswers(List<ParticipantAnswer> answers) {
+        dooitSharedPreferences.setComplex(QUIZ_ANSWERS, answers);
+    }
+
+    public List<ParticipantAnswer> loadQuizChallengeAnswers() {
+        ListParameterizedType type = new ListParameterizedType(ParticipantAnswer.class);
+        return (List<ParticipantAnswer>) dooitSharedPreferences.getComplex(QUIZ_ANSWERS, type.getClass());
+    }
+
+    public void clearQuizChallengeAnswers() {
+        dooitSharedPreferences.remove(QUIZ_ANSWERS);
     }
 
     /*** Tips ***/

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
@@ -6,7 +6,6 @@ import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
-import com.google.gson.reflect.TypeToken;
 
 import org.gem.indo.dooit.DooitApplication;
 import org.gem.indo.dooit.helpers.bot.ListParameterizedType;
@@ -25,10 +24,8 @@ import org.gem.indo.dooit.models.enums.BotType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.lang.reflect.Type;
 
 import javax.inject.Inject;
 
@@ -209,11 +206,7 @@ public class Persisted {
 
     public List<ParticipantAnswer> loadQuizChallengeAnswers() {
         ListParameterizedType type = new ListParameterizedType(ParticipantAnswer.class);
-        ParticipantAnswer[] answers = dooitSharedPreferences.getComplex(QUIZ_ANSWERS, ParticipantAnswer[].class);
-        if (answers != null)
-            return new ArrayList<>(Arrays.asList(answers));
-        return new ArrayList<ParticipantAnswer>();
-//        return dooitSharedPreferences.getComplex(QUIZ_ANSWERS, type.getClass());
+        return dooitSharedPreferences.getComplex(QUIZ_ANSWERS, type);
     }
 
     public void clearQuizChallengeAnswers() {

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
@@ -150,12 +150,12 @@ public class Persisted {
         dooitSharedPreferences.setComplex(CHALLENGE, activeChallenge);
     }
 
-    public Object getCurrentChallenge() {
+    public BaseChallenge getCurrentChallenge() {
         return loadCurrentChallenge();
     }
 
     private BaseChallenge loadCurrentChallenge() {
-        return dooitSharedPreferences.getComplex(TOKEN, BaseChallenge.class);
+        return dooitSharedPreferences.getComplex(CHALLENGE, BaseChallenge.class);
     }
 
     public boolean hasCurrentChallenge() {

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
@@ -163,6 +163,10 @@ public class Persisted {
         return challenge != null;
     }
 
+    public void clearCurrentChallenge() {
+        dooitSharedPreferences.remove(CHALLENGE);
+    }
+
     /*** Tips ***/
 
     public List<Tip> getTips() {

--- a/app/src/main/java/org/gem/indo/dooit/helpers/challenge/MapParameterizedType.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/challenge/MapParameterizedType.java
@@ -1,0 +1,35 @@
+package org.gem.indo.dooit.helpers.challenge;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+/**
+ * Created by Rudolph Jacobs on 2016-11-29.
+ */
+
+public class MapParameterizedType implements ParameterizedType {
+
+    private Type keyType;
+    private Type valType;
+
+    public MapParameterizedType(Type keyType, Type valType) {
+        this.keyType = keyType;
+        this.valType = valType;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+        return new Type[]{keyType, valType};
+    }
+
+    @Override
+    public Type getRawType() {
+        return HashMap.class;
+    }
+
+    @Override
+    public Type getOwnerType() {
+        return null;
+    }
+}

--- a/app/src/main/java/org/gem/indo/dooit/models/challenge/QuizChallengeQuestionState.java
+++ b/app/src/main/java/org/gem/indo/dooit/models/challenge/QuizChallengeQuestionState.java
@@ -1,0 +1,15 @@
+package org.gem.indo.dooit.models.challenge;
+
+/**
+ * Created by Rudolph Jacobs on 2016-11-29.
+ */
+
+public class QuizChallengeQuestionState {
+    public long optionId = -1;
+    public boolean completed = false;
+
+    public QuizChallengeQuestionState(long optionId, boolean completed) {
+        this.optionId = optionId;
+        this.completed = completed;
+    }
+}

--- a/app/src/main/java/org/gem/indo/dooit/models/challenge/QuizChallengeQuestionState.java
+++ b/app/src/main/java/org/gem/indo/dooit/models/challenge/QuizChallengeQuestionState.java
@@ -1,10 +1,12 @@
 package org.gem.indo.dooit.models.challenge;
 
+import java.io.Serializable;
+
 /**
  * Created by Rudolph Jacobs on 2016-11-29.
  */
 
-public class QuizChallengeQuestionState {
+public class QuizChallengeQuestionState implements Serializable {
     public long optionId = -1;
     public boolean completed = false;
 

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/ChallengeFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/ChallengeFragment.java
@@ -117,8 +117,12 @@ public class ChallengeFragment extends MainFragment {
         if (persisted.hasCurrentChallenge()) {
             try {
                 challenge = (BaseChallenge) persisted.getCurrentChallenge();
-                loadTypeFragment(challenge, true);
-                return;
+                if (challenge.getDeactivationDate().isBeforeNow()) {
+                    persisted.clearCurrentChallenge();
+                } else {
+                    loadTypeFragment(challenge, true);
+                    return;
+                }
             } catch (Exception e) {
                 Log.d(TAG, "Could not load persisted challenge");
                 persisted.clearCurrentChallenge();

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/ChallengeFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/ChallengeFragment.java
@@ -77,10 +77,6 @@ public class ChallengeFragment extends MainFragment {
         unbinder = ButterKnife.bind(this, view);
         progressBar.setVisibility(View.VISIBLE);
         progressText.setVisibility(View.VISIBLE);
-////        if (persisted.hasCurrentChallenge()) {
-////            challenge = (BaseChallenge) persisted.getCurrentChallenge();
-////            startChallenge();
-////        }
         return view;
     }
 
@@ -94,8 +90,36 @@ public class ChallengeFragment extends MainFragment {
         super.onDestroyView();
     }
 
+    private void loadTypeFragment(BaseChallenge challenge) {
+        if (challenge != null) {
+            ChallengeFragment.this.challenge = challenge;
+            persisted.setActiveChallenge(challenge);
+
+            if (getActivity() != null) {
+                FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
+                Fragment fragment = ChallengeRegisterFragment.newInstance();
+                Bundle args = new Bundle();
+                args.putParcelable("challenge", challenge);
+                fragment.setArguments(args);
+                ft.replace(R.id.fragment_challenge_container, fragment, "fragment_challenge");
+                ft.commit();
+            }
+        } else {
+            FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
+            Fragment fragment = ChallengeNoneFragment.newInstance();
+            ft.replace(R.id.fragment_challenge_container, fragment);
+            ft.commit();
+        }
+    }
+
     @Override
     public void onStart() {
+//        if (persisted.hasCurrentChallenge()) {
+//            challenge = (BaseChallenge) persisted.getCurrentChallenge();
+//            startChallenge();
+//            return;
+//        }
+
         super.onStart();
         challengeSubscription = challengeManager.retrieveCurrentChallenge(false, new DooitErrorHandler() {
             @Override
@@ -108,26 +132,7 @@ public class ChallengeFragment extends MainFragment {
                 .subscribe(new Action1<BaseChallenge>() {
                     @Override
                     public void call(BaseChallenge challenge) {
-                        if (challenge != null) {
-                            ChallengeFragment.this.challenge = challenge;
-                            persisted.setActiveChallenge(challenge);
-
-                            if (getActivity() == null) return;
-                            if (getActivity().findViewById(R.id.fragment_challenge_container) != null) {
-                                FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
-                                Fragment fragment = ChallengeRegisterFragment.newInstance();
-                                Bundle args = new Bundle();
-                                args.putParcelable("challenge", challenge);
-                                fragment.setArguments(args);
-                                ft.replace(R.id.fragment_challenge_container, fragment, "fragment_challenge");
-                                ft.commit();
-                            }
-                        } else {
-                            FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
-                            Fragment fragment = ChallengeNoneFragment.newInstance();
-                            ft.replace(R.id.fragment_challenge_container, fragment);
-                            ft.commit();
-                        }
+                        loadTypeFragment(challenge);
                         getActivity().runOnUiThread(new Runnable() {
                             @Override
                             public void run() {

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/ChallengeFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/ChallengeFragment.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -34,6 +35,7 @@ import rx.functions.Action0;
 import rx.functions.Action1;
 
 public class ChallengeFragment extends MainFragment {
+    public static String TAG = "ChallengeMain";
 
     @Inject
     ChallengeManager challengeManager;
@@ -90,17 +92,13 @@ public class ChallengeFragment extends MainFragment {
         super.onDestroyView();
     }
 
-    private void loadTypeFragment(BaseChallenge challenge) {
+    private void loadTypeFragment(BaseChallenge challenge, boolean hasActive) {
         if (challenge != null) {
             ChallengeFragment.this.challenge = challenge;
-            persisted.setActiveChallenge(challenge);
 
             if (getActivity() != null) {
                 FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
-                Fragment fragment = ChallengeRegisterFragment.newInstance();
-                Bundle args = new Bundle();
-                args.putParcelable("challenge", challenge);
-                fragment.setArguments(args);
+                Fragment fragment = ChallengeRegisterFragment.newInstance(challenge, hasActive);
                 ft.replace(R.id.fragment_challenge_container, fragment, "fragment_challenge");
                 ft.commit();
             }
@@ -114,17 +112,23 @@ public class ChallengeFragment extends MainFragment {
 
     @Override
     public void onStart() {
-//        if (persisted.hasCurrentChallenge()) {
-//            challenge = (BaseChallenge) persisted.getCurrentChallenge();
-//            startChallenge();
-//            return;
-//        }
-
         super.onStart();
+
+        if (persisted.hasCurrentChallenge()) {
+            try {
+                challenge = (BaseChallenge) persisted.getCurrentChallenge();
+                loadTypeFragment(challenge, true);
+                return;
+            } catch (Exception e) {
+                Log.d(TAG, "Could not load persisted challenge");
+                persisted.clearCurrentChallenge();
+            }
+        }
+
         challengeSubscription = challengeManager.retrieveCurrentChallenge(false, new DooitErrorHandler() {
             @Override
             public void onError(DooitAPIError error) {
-                Toast.makeText(getContext(), "Could not retrieve challenges", Toast.LENGTH_SHORT).show();
+                Toast.makeText(getContext(), "Could not retrieve challenge", Toast.LENGTH_SHORT).show();
             }
         });
 
@@ -132,7 +136,7 @@ public class ChallengeFragment extends MainFragment {
                 .subscribe(new Action1<BaseChallenge>() {
                     @Override
                     public void call(BaseChallenge challenge) {
-                        loadTypeFragment(challenge);
+                        loadTypeFragment(challenge, false);
                         getActivity().runOnUiThread(new Runnable() {
                             @Override
                             public void run() {

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeFreeformFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeFreeformFragment.java
@@ -146,6 +146,7 @@ public class ChallengeFreeformFragment extends Fragment {
                 Log.d(TAG, "Entry submitted");
             }
         });
+        persisted.clearCurrentChallenge();
     }
 
     @OnClick(R.id.fragment_challenge_freeform_submitbutton)

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizFragment.java
@@ -196,11 +196,16 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
             @Override
             public void onError(DooitAPIError error) {
                 Log.d(TAG, "Could not submit challenge entry");
+                FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
+                Fragment f = ChallengeFragment.newInstance();
+                ft.replace(R.id.fragment_challenge_container, f, "fragment_challenge");
+                ft.commit();
             }
         }).subscribe(new Action1<QuizChallengeEntry>() {
             @Override
             public void call(QuizChallengeEntry entry) {
                 Log.d(TAG, "Entry submitted");
+                persisted.clearCurrentChallenge();
                 clearState();
                 challengeCompleted = true;
                 FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizFragment.java
@@ -27,6 +27,7 @@ import org.gem.indo.dooit.models.challenge.QuizChallenge;
 import org.gem.indo.dooit.models.challenge.QuizChallengeEntry;
 import org.gem.indo.dooit.models.challenge.QuizChallengeOption;
 import org.gem.indo.dooit.models.challenge.QuizChallengeQuestion;
+import org.gem.indo.dooit.models.challenge.QuizChallengeQuestionState;
 import org.gem.indo.dooit.views.main.fragments.challenge.adapters.ChallengeQuizPagerAdapter;
 import org.gem.indo.dooit.views.main.fragments.challenge.interfaces.OnOptionChangeListener;
 import org.gem.indo.dooit.views.main.fragments.challenge.interfaces.OnQuestionCompletedListener;
@@ -81,7 +82,7 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
 
     private ChallengeQuizPagerAdapter mAdapter;
     private List<ParticipantAnswer> answers = new ArrayList<ParticipantAnswer>();
-    private Map<Long, QuestionState> selections = new HashMap<>();
+    private Map<Long, QuizChallengeQuestionState> selections = new HashMap<>();
     private Participant participant;
     private QuizChallenge mChallenge;
     private QuizChallengeOption currentOption = null;
@@ -265,7 +266,7 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
         currentQuestion = question;
         currentOption = option;
         long questionId = question.getId();
-        selections.put(questionId, new QuestionState(option.getId(), isCompleted(questionId)));
+        selections.put(questionId, new QuizChallengeQuestionState(option.getId(), isCompleted(questionId)));
         for (OnOptionChangeListener l : optionChangeListeners) {
             if (l != null) {
                 l.onOptionChange(question, option);
@@ -283,7 +284,7 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
 
     public void setCompleted(long questionId) {
         if (selections.containsKey(questionId)) {
-            selections.put(questionId, new QuestionState(selections.get(questionId).optionId, true));
+            selections.put(questionId, new QuizChallengeQuestionState(selections.get(questionId).optionId, true));
         }
         for (OnQuestionCompletedListener l : questionCompletedListeners) {
             if (l != null) {
@@ -302,19 +303,9 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
 
     public int numCompleted() {
         int total = 0;
-        for (QuestionState state : selections.values()) {
+        for (QuizChallengeQuestionState state : selections.values()) {
             total += state.completed ? 1 : 0;
         }
         return total;
-    }
-
-    private class QuestionState {
-        private long optionId = -1;
-        private boolean completed = false;
-
-        QuestionState(long optionId, boolean completed) {
-            this.optionId = optionId;
-            this.completed = completed;
-        }
     }
 }

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizFragment.java
@@ -334,7 +334,6 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
     }
 
     private void saveState() {
-        persisted.saveQuizChallengeIndex(mPager.getCurrentItem());
         persisted.saveQuizChallengeState(selections);
         persisted.saveQuizChallengeAnswers(answers);
     }
@@ -342,15 +341,12 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
     private void loadState() {
         Map<Long, QuizChallengeQuestionState> state = null;
         List<ParticipantAnswer> prevAnswers = null;
-        int idx = -1;
         try {
-            Log.d(TAG, "Loading state. (0/3)");
+            Log.d(TAG, "Loading state. (0/2)");
             state = persisted.loadQuizChallengeState();
-            Log.d(TAG, "Loading answers. (1/3)");
+            Log.d(TAG, "Loading answers. (1/2)");
             prevAnswers = persisted.loadQuizChallengeAnswers();
-            Log.d(TAG, "Loading page index. (2/3)");
-            idx = persisted.loadQuizChallengeIndex();
-            Log.d(TAG, "State fully loaded. (3/3)");
+            Log.d(TAG, "Loading page index. (2/2)");
         } catch (Exception e) {
             Log.d(TAG, "Failed to load quiz state. Resetting.");
             e.printStackTrace();
@@ -366,7 +362,7 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
         }
 
         int len = mChallenge.numQuestions();
-        idx = 0;
+        int idx = 0;
         List<QuizChallengeQuestion > questions = mChallenge.getQuestions();
         while (idx < len && isCompleted(questions.get(idx).getId())) {
             idx++;
@@ -377,6 +373,5 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
     private void clearState() {
         persisted.clearQuizChallengeState();
         persisted.clearQuizChallengeAnswers();
-        persisted.clearQuizChallengeIndex();
     }
 }

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizFragment.java
@@ -28,6 +28,7 @@ import org.gem.indo.dooit.models.challenge.QuizChallengeEntry;
 import org.gem.indo.dooit.models.challenge.QuizChallengeOption;
 import org.gem.indo.dooit.models.challenge.QuizChallengeQuestion;
 import org.gem.indo.dooit.models.challenge.QuizChallengeQuestionState;
+import org.gem.indo.dooit.views.main.fragments.challenge.ChallengeFragment;
 import org.gem.indo.dooit.views.main.fragments.challenge.adapters.ChallengeQuizPagerAdapter;
 import org.gem.indo.dooit.views.main.fragments.challenge.interfaces.OnOptionChangeListener;
 import org.gem.indo.dooit.views.main.fragments.challenge.interfaces.OnQuestionCompletedListener;
@@ -80,6 +81,7 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
     @BindView(org.gem.indo.dooit.R.id.fragment_challenge_quiz_checkbutton)
     Button checkButton;
 
+    private boolean challengeCompleted = false;
     private ChallengeQuizPagerAdapter mAdapter;
     private List<ParticipantAnswer> answers = new ArrayList<ParticipantAnswer>();
     private Map<Long, QuizChallengeQuestionState> selections = new HashMap<>();
@@ -199,9 +201,11 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
             @Override
             public void call(QuizChallengeEntry entry) {
                 Log.d(TAG, "Entry submitted");
+                clearState();
+                challengeCompleted = true;
                 FragmentTransaction ft = getActivity().getSupportFragmentManager().beginTransaction();
-                Fragment fragment = ChallengeNoneFragment.newInstance("Thank you for participating!");
-                ft.replace(R.id.fragment_challenge_container, fragment, "fragment_challenge");
+                Fragment f = ChallengeFragment.newInstance();
+                ft.replace(R.id.fragment_challenge_container, f, "fragment_challenge");
                 ft.commit();
             }
         });
@@ -244,7 +248,7 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
 
     @OnPageChange(R.id.fragment_challenge_quiz_pager)
     public void onPageSelected(int position) {
-        Log.d(TAG, "Page change: " + String.valueOf(position));
+        Log.d(TAG, "Quiz page change: " + String.valueOf(position));
         updateProgressCounter(position);
         if (position == mAdapter.getCount() - 1) {
             checkButton.setText(org.gem.indo.dooit.R.string.label_done);
@@ -307,5 +311,72 @@ public class ChallengeQuizFragment extends Fragment implements OnOptionChangeLis
             total += state.completed ? 1 : 0;
         }
         return total;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        loadState();
+    }
+
+    @Override
+    public void onStop() {
+        if (!challengeCompleted) {
+            saveState();
+        }
+        super.onStop();
+    }
+
+    public int calcPagerIdx(int idx) {
+        if (idx >= mPager.getChildCount()) idx = mPager.getChildCount() - 1;
+        if (idx < 0) idx = 0;
+        return idx;
+    }
+
+    private void saveState() {
+        persisted.saveQuizChallengeIndex(mPager.getCurrentItem());
+        persisted.saveQuizChallengeState(selections);
+        persisted.saveQuizChallengeAnswers(answers);
+    }
+
+    private void loadState() {
+        Map<Long, QuizChallengeQuestionState> state = null;
+        List<ParticipantAnswer> prevAnswers = null;
+        int idx = -1;
+        try {
+            Log.d(TAG, "Loading state. (0/3)");
+            state = persisted.loadQuizChallengeState();
+            Log.d(TAG, "Loading answers. (1/3)");
+            prevAnswers = persisted.loadQuizChallengeAnswers();
+            Log.d(TAG, "Loading page index. (2/3)");
+            idx = persisted.loadQuizChallengeIndex();
+            Log.d(TAG, "State fully loaded. (3/3)");
+        } catch (Exception e) {
+            Log.d(TAG, "Failed to load quiz state. Resetting.");
+            e.printStackTrace();
+            clearState();
+        }
+
+        if (state != null) {
+            selections = state;
+        }
+
+        if (prevAnswers != null) {
+            answers = persisted.loadQuizChallengeAnswers();
+        }
+
+        int len = mChallenge.numQuestions();
+        idx = 0;
+        List<QuizChallengeQuestion > questions = mChallenge.getQuestions();
+        while (idx < len && isCompleted(questions.get(idx).getId())) {
+            idx++;
+        }
+        mPager.setCurrentItem(idx);
+    }
+
+    private void clearState() {
+        persisted.clearQuizChallengeState();
+        persisted.clearQuizChallengeAnswers();
+        persisted.clearQuizChallengeIndex();
     }
 }

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizQuestionFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeQuizQuestionFragment.java
@@ -85,7 +85,6 @@ public class ChallengeQuizQuestionFragment extends Fragment implements OnOptionC
         if (challengeFragment instanceof ChallengeQuizFragment) {
             controller = ((ChallengeQuizFragment) challengeFragment);
             controller.addOptionChangeListener(this);
-//            controller.addQuestionCompletedListener(this);
         }
     }
 

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeRegisterFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeRegisterFragment.java
@@ -3,6 +3,7 @@ package org.gem.indo.dooit.views.main.fragments.challenge.fragments;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,6 +18,7 @@ import org.gem.indo.dooit.R;
 import org.gem.indo.dooit.api.DooitAPIError;
 import org.gem.indo.dooit.api.DooitErrorHandler;
 import org.gem.indo.dooit.api.managers.ChallengeManager;
+import org.gem.indo.dooit.helpers.Persisted;
 import org.gem.indo.dooit.helpers.SquiggleBackgroundHelper;
 import org.gem.indo.dooit.models.challenge.BaseChallenge;
 import org.gem.indo.dooit.models.challenge.FreeformChallenge;
@@ -40,10 +42,14 @@ import rx.functions.Action1;
  * create an instance of this fragment.
  */
 public class ChallengeRegisterFragment extends Fragment {
+    private static final String TAG = "ChallengeRegister";
     private static final String ARG_CHALLENGE = "challenge";
 
     @Inject
     ChallengeManager challengeManager;
+
+    @Inject
+    Persisted persist;
 
     @BindView(R.id.fragment_challenge_container)
     View background;
@@ -181,6 +187,7 @@ public class ChallengeRegisterFragment extends Fragment {
         participantSubscription.subscribe(new Action1<Participant>() {
             @Override
             public void call(Participant participant1) {
+                persist.setActiveChallenge(challenge);
                 startChallenge(participant1);
             }
         });

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeRegisterFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengeRegisterFragment.java
@@ -44,6 +44,7 @@ import rx.functions.Action1;
 public class ChallengeRegisterFragment extends Fragment {
     private static final String TAG = "ChallengeRegister";
     private static final String ARG_CHALLENGE = "challenge";
+    private static final String ARG_HASACTIVE = "has_active";
 
     @Inject
     ChallengeManager challengeManager;
@@ -75,6 +76,7 @@ public class ChallengeRegisterFragment extends Fragment {
     @BindView(R.id.fragment_challenge_register_button)
     Button register;
 
+    private boolean hasActive = false;
     private BaseChallenge challenge;
     private Observable<Participant> participantSubscription = null;
     private Unbinder unbinder = null;
@@ -83,16 +85,20 @@ public class ChallengeRegisterFragment extends Fragment {
         // Required empty public constructor
     }
 
-    /**
-     * Use this factory method to create a new instance of
-     * this fragment using the provided parameters.
-     *
-     * @return A new instance of fragment ChallengeRegisterFragment.
-     */
-    // TODO: Rename and change types and number of parameters
-    public static ChallengeRegisterFragment newInstance() {
+    public static ChallengeRegisterFragment newInstance(BaseChallenge challenge) {
         ChallengeRegisterFragment fragment = new ChallengeRegisterFragment();
         Bundle args = new Bundle();
+        args.putParcelable(ARG_CHALLENGE, challenge);
+        args.putBoolean(ARG_HASACTIVE, false);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    public static ChallengeRegisterFragment newInstance(BaseChallenge challenge, boolean hasActive) {
+        ChallengeRegisterFragment fragment = new ChallengeRegisterFragment();
+        Bundle args = new Bundle();
+        args.putParcelable(ARG_CHALLENGE, challenge);
+        args.putBoolean(ARG_HASACTIVE, hasActive);
         fragment.setArguments(args);
         return fragment;
     }
@@ -102,6 +108,7 @@ public class ChallengeRegisterFragment extends Fragment {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
             challenge = getArguments().getParcelable(ARG_CHALLENGE);
+            hasActive = getArguments().getBoolean(ARG_HASACTIVE);
         }
         ((DooitApplication) getActivity().getApplication()).component.inject(this);
     }
@@ -112,6 +119,9 @@ public class ChallengeRegisterFragment extends Fragment {
         View view = inflater.inflate(org.gem.indo.dooit.R.layout.fragment_challenge_register, container, false);
         unbinder = ButterKnife.bind(this, view);
         SquiggleBackgroundHelper.setBackground(getContext(), R.color.grey_back, R.color.grey_fore, background);
+        if (hasActive) {
+            register.setText(getText(R.string.label_continue));
+        }
         return view;
     }
 


### PR DESCRIPTION
- [X] Add challenge persistence on challenge manager.
- [X] Fetch persisted challenge on challenge activity load.
- [X] Clear challenge data on exceptions.
- [X] Clear active challenge data if expired.

Other:
- [X] Add parameterized map type.
- [X] Add type-based complex-object getter in shared preferences.
- [X] Remove old module.