### PR TITLE
Return size of 0 if no goal prototypes found.

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/adapters/GoalGalleryAdapter.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/adapters/GoalGalleryAdapter.java
@@ -31,7 +31,7 @@ public class GoalGalleryAdapter extends RecyclerView.Adapter<AnswerGoalGalleryIt
 
     @Override
     public int getItemCount() {
-        return prototypes.size();
+        return prototypes == null ? 0 : prototypes.size();
     }
 
     @Override


### PR DESCRIPTION
Prevents crashes when no goal prototypes were found.