### PR TITLE
Send language header to backend

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/api/managers/DooitManager.java
+++ b/app/src/main/java/org/gem/indo/dooit/api/managers/DooitManager.java
@@ -18,6 +18,7 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import javax.inject.Inject;
 
@@ -68,9 +69,15 @@ public class DooitManager {
             public Response intercept(Chain chain) throws IOException {
                 Request original = chain.request();
 
+                // Backend framework uses "id" for Indonesian
+                String langCode = Locale.getDefault().getLanguage();
+                if (langCode.toLowerCase().equals("in"))
+                    langCode = "id";
+
                 Request.Builder requestBuilder = original.newBuilder()
                         .url(original.url())
                         .addHeader("Accept", "application/json")
+                        .addHeader("Accept-Language", langCode)
                         .method(original.method(), original.body());
 
                 requestBuilder = addTokenToRequest(requestBuilder);


### PR DESCRIPTION
Language header is now set in each HTTP request made by a `DooitManager`. I have tested that Django recognises it and returns translated text. The associated backend PR is https://github.com/praekeltfoundation/gem-bbb-indo-server/pull/58

An example of a translated error message:

```json
{
  "status_code": 400,
  "errors": [
    "Sandi yang Anda masukkan tidak cocok."
  ],
  "rel_errors": {},
  "field_errors": {}
}
```