### PR TITLE
Goal Add Conversation end nodes

### DIFF
--- a/app/release-notes.txt
+++ b/app/release-notes.txt
@@ -16,4 +16,4 @@
 - Quiz has a visible scrollbar
 - Right nav arrow only shows when there is more than one Goal
 - Made margins of toolbar elements on profile screen equidistant
-
+- Goal add conversation now allows user ot change date or amount

--- a/app/src/main/res/raw/goal_add.json
+++ b/app/src/main/res/raw/goal_add.json
@@ -217,12 +217,12 @@
       {
         "name": "changeDate",
         "text": "$(changeDate)",
-        "next": "askGoalDateCustom"
+        "next": "goal_add_q_change_date"
       },
       {
         "name": "changeAmount",
         "text": "$(changeAmount)",
-        "next": "goal_add_q_ask_amount"
+        "next": "goal_add_q_change_target"
       },
       {
         "name": "startOver",
@@ -232,6 +232,38 @@
     ]
   },
 
+
+
+  {
+    "name": "goal_add_q_change_date",
+    "type": "blank",
+    "autoAnswer": "goalDate",
+    "answers": [
+      {
+        "name": "goalDate",
+        "nextOnFinish": "goal_add_q_verify",
+        "type": "inlineDate",
+        "inlineEditHint": "$(type_date_hint)"
+      }
+    ]
+  },
+
+
+
+  {
+    "name": "goal_add_q_change_target",
+    "type": "blank",
+    "autoAnswer": "goal_amount",
+    "answers": [
+      {
+        "name": "goal_amount",
+        "nextOnFinish": "goal_add_q_verify",
+        "type": "inlineCurrency",
+        "typeOnFinish": "textCurrency",
+        "inlineEditHint": "$(type_currency_hint)"
+      }
+    ]
+  },
 
 
 

--- a/app/src/main/res/raw/goal_add.json
+++ b/app/src/main/res/raw/goal_add.json
@@ -217,12 +217,12 @@
       {
         "name": "changeDate",
         "text": "$(changeDate)",
-        "next": "askGoalDate"
+        "next": "askGoalDateCustom"
       },
       {
         "name": "changeAmount",
         "text": "$(changeAmount)",
-        "next": "askGoalAmount"
+        "next": "goal_add_q_ask_amount"
       },
       {
         "name": "startOver",


### PR DESCRIPTION
The Goal Add conversation ends with options to change the values previously entered in the conversation.

The change date option was not directing properly.