### PR TITLE
Crash On ImageActivity

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/views/onboarding/ProfileImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/onboarding/ProfileImageActivity.java
@@ -106,7 +106,9 @@ public class ProfileImageActivity extends ImageActivity {
             @Override
             public void call(Response<EmptyResponse> response) {
                 User user = persisted.getCurrentUser();
-                user.getProfile().setProfileImageUrl(getImageUri().toString());
+                if(user != null && user.getProfile() != null && getImageUri() != null) {
+                    user.getProfile().setProfileImageUrl(getImageUri().toString());
+                }
                 persisted.setCurrentUser(user);
                 MainActivity.Builder.create(ProfileImageActivity.this).startActivityClearTop();
             }


### PR DESCRIPTION
Issues #440, I Could not replicated the crash, but I put in checks tO ensure that a NullPointerException could not occur at line that caused the crash