### PR TITLE
Fix Arc Progress Bar 

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/views/custom/ArcProgressBar.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/custom/ArcProgressBar.java
@@ -280,8 +280,11 @@ public class ArcProgressBar extends View {
         paint.setColor(unfinishedStrokeColor);
         canvas.drawArc(rectF, startAngle, arcAngle, false, paint);
         paint.setColor(finishedStrokeColor);
-        canvas.drawArc(rectF, finishedStartAngle, finishedSweepAngle, false, paint);
 
+        // On some devices, irrespective of API level, drawing the arc with a sweep angle of 0f
+        // causes it to wrap around to 360 degrees.
+        if (finishedSweepAngle == 0f) finishedSweepAngle = 0.0001f;
+        canvas.drawArc(rectF, finishedStartAngle, finishedSweepAngle, false, paint);
 
         if (arcBottomHeight == 0) {
             float radius = getWidth() / 2f;


### PR DESCRIPTION
Setting an arc's sweeping angle to `0.0f` causes it to wrap around to `360f` on some devices. API level does not seem to have an effect.

It could be differences in floating point math between the devices, on a C/C++ level.

Fixes https://github.com/praekeltfoundation/gem-bbb-indo/issues/213