### PR TITLE
Fix Done option not appearing for bot currency input

### DIFF
--- a/app/src/main/res/layout/item_view_bot_inline_edit_currency.xml
+++ b/app/src/main/res/layout/item_view_bot_inline_edit_currency.xml
@@ -32,6 +32,7 @@
             style="@style/AppTheme.TextView.Regular.Large"
             android:layout_width="200dp"
             android:layout_height="wrap_content"
+            android:imeOptions="actionDone"
             android:layout_toRightOf="@+id/item_view_bot_inline_edit_currency_view"
             android:layout_centerVertical="true"
             android:background="@android:color/transparent"


### PR DESCRIPTION
On a Sony Xperia, API level 17, the Xperia keyboard showed *Next* as the IME option and not Done.