### PR TITLE
GEMINDO-90 Direct Bot to Tips with initial query

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/OnTipsAvailableListener.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/OnTipsAvailableListener.java
@@ -10,5 +10,4 @@ import java.util.List;
 
 public interface OnTipsAvailableListener {
     void onTipsAvailable(List<Tip> tips);
-    void hideFiltering();
 }

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/TipsFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/TipsFragment.java
@@ -86,7 +86,7 @@ public class TipsFragment extends MainFragment implements OnTipsAvailableListene
     /**
      * Set to true if the Fragment was opened with an initial search query.
      */
-    private boolean initialQuery = false;
+    private boolean filtering = false;
 
     public TipsFragment() {
         // Required empty public constructor
@@ -152,7 +152,7 @@ public class TipsFragment extends MainFragment implements OnTipsAvailableListene
                 final String query = args.getString(ARG_SEARCH_QUERY);
                 if (!TextUtils.isEmpty(query)) {
                     searchView.setText(query);
-                    initialQuery = true;
+                    filtering = true;
                 }
             }
 
@@ -189,11 +189,6 @@ public class TipsFragment extends MainFragment implements OnTipsAvailableListene
         if (focus != null) {
             imm.hideSoftInputFromWindow(focus.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
         }
-
-        //imm.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0);
-
-        //imm.hideSoftInputFromWindow( this.viewPager.getWindowToken(), InputMethodManager.HIDE_IMPLICIT_ONLY, null);
-
     }
 
     @OnTouch(R.id.fragment_tips_search_view)
@@ -242,14 +237,14 @@ public class TipsFragment extends MainFragment implements OnTipsAvailableListene
         searchAdapter.updateAllTips(tips);
 
         // Filter Tips if search query is populated
-        if (initialQuery) {
+        if (filtering) {
             String query = searchView.getText().toString();
             TipsListFragment fragment = tipsTabAdapter.getPrimaryItem();
             if (fragment != null) {
                 showFiltering(query);
                 fragment.onSearch(query);
             }
-            initialQuery = false;
+            filtering = false;
         }
     }
 

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/TipsListFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/TipsListFragment.java
@@ -97,7 +97,7 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
         } else {
             retrieveTips();
         }
-        hideFiltering();
+//        hideFiltering();
     }
 
     @Override
@@ -117,7 +117,7 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
         } else {
             retrieveTips();
         }
-        hideFiltering();
+//        hideFiltering();
     }
 
     @Override
@@ -248,8 +248,6 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
     protected void hideFiltering() {
         if (listener != null)
             listener.hideFiltering();
-        else
-            System.out.println("filtering not set");
     }
 
     @Override

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/TipsListFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/TipsListFragment.java
@@ -8,10 +8,7 @@ import android.support.v4.app.Fragment;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RelativeLayout;
@@ -87,23 +84,8 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        super.onCreateOptionsMenu(menu, inflater);
-        if (tipProvider.hasTips()) {
-            List<Tip> tips = tipProvider.loadTips();
-            adapter.updateAllTips(tips);
-            adapter.resetFiltered();
-            notifyTipsLoaded(tips);
-        } else {
-            retrieveTips();
-        }
-//        hideFiltering();
-    }
-
-    @Override
     public void onPause() {
         super.onPause();
-        tipProvider.saveTips(adapter.getAllTips());
     }
 
     @Override
@@ -117,7 +99,17 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
         } else {
             retrieveTips();
         }
-//        hideFiltering();
+    }
+
+    public void onActive() {
+        if (tipProvider.hasTips()) {
+            List<Tip> tips = tipProvider.loadTips();
+            adapter.updateAllTips(tips);
+            adapter.resetFiltered();
+            notifyTipsLoaded(tips);
+        } else {
+            retrieveTips();
+        }
     }
 
     @Override
@@ -158,8 +150,7 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
         adapter.getFilter().filter(constraint);
     }
 
-    public void clearFilter(View v) {
-        hideFiltering();
+    public void clearFilter() {
         adapter.resetFiltered();
         if (snackbar != null) {
             snackbar.dismiss();
@@ -167,17 +158,13 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
     }
 
     public void onPageSelected() {
-        if (snackbar != null) {
+        if (snackbar != null)
             snackbar.dismiss();
-        }
-        Log.d(TAG, "onPageSelected");
     }
 
     public void onPageDeselected() {
-        if (snackbar != null) {
+        if (snackbar != null)
             snackbar.dismiss();
-        }
-        Log.d(TAG, "onPageDeselected");
     }
 
     public void setOnTipsLoadedListener(OnTipsAvailableListener listener) {
@@ -224,7 +211,8 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
                             }
 
                             adapter.updateAllTips(tips);
-                            adapter.resetFiltered();
+                            if (tipProvider != null)
+                                tipProvider.saveTips(tips);
                             notifyTipsLoaded(tips);
                         }
                     });
@@ -245,15 +233,8 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
             progressContainer.setVisibility(View.VISIBLE);
     }
 
-    protected void hideFiltering() {
-        if (listener != null)
-            listener.hideFiltering();
-    }
-
     @Override
     public void onFilterDone(int filterCount) {
-        Log.d(TAG, "onVariableChanged function called!!!!!!!!!");
-
         if (recyclerView != null) {
             if (snackbar == null)
                 snackbar = Snackbar.make(recyclerView, R.string.tips_no_tips_on_filter, Snackbar.LENGTH_INDEFINITE);

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/viewholders/TipViewHolder.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/viewholders/TipViewHolder.java
@@ -136,6 +136,8 @@ public class TipViewHolder extends RecyclerView.ViewHolder {
                         @Override
                         public void run() {
                             setFavourite(false);
+                            // Clear tips so favourite button state can be updated on new Tips download
+                            persisted.clearTips();
                             persisted.clearFavourites();
                             Toast.makeText(getContext(), String.format(removeFavArticleText,
                                     titleView.getText().toString()), Toast.LENGTH_SHORT).show();
@@ -156,6 +158,8 @@ public class TipViewHolder extends RecyclerView.ViewHolder {
                         @Override
                         public void run() {
                             setFavourite(true);
+                            // Clear tips so favourite button state can be updated on new Tips download
+                            persisted.clearTips();
                             persisted.clearFavourites();
                             Toast.makeText(getContext(), String.format(addFavArticleText,
                                     titleView.getText().toString()), Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
This PR makes changes to the Tip screen in order to support an initial search query. The `TipsListFragment` no longer hides the filtering, and the parent `TipsFragment` decides if the list should be filtered when the async call returns.

The functionality of the Tips screen changed slightly. When a list is filtered, and tabbing to the other list (Favourites or All) the filtering will not be cleared.