### PR TITLE
bugfix/GEMINDO-213 Deserialisation crash

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/helpers/ValueMap.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/ValueMap.java
@@ -66,7 +66,13 @@ public class ValueMap {
     }
 
     public Long getLong(String key) {
-        return (Long) map.get(key);
+        // Crash occurred when casting a double to a long
+        // Long inherits from Number, so hopefully this casting will work
+        try {
+            return (Long) map.get(key);
+        } catch (ClassCastException e) {
+            return ((Number) map.get(key)).longValue();
+        }
     }
 
     /*********


### PR DESCRIPTION
A crash occurred when casting from double to long (Presumably casting something like 5.0)
`return (Long) map.get(key);`
I changed it so I first cast it to Number, then use the `getLong()` function to get the Long value.
`return ((Number) map.get(key)).longValue();`

This should fix this issue, and will drop all decimal places.
