### PR TITLE
Bugfix/Challenge Notification Conditions

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/api/responses/ChallengeParticipatedResponse.java
+++ b/app/src/main/java/org/gem/indo/dooit/api/responses/ChallengeParticipatedResponse.java
@@ -9,13 +9,13 @@ import org.gem.indo.dooit.models.challenge.BaseChallenge;
  */
 
 public class ChallengeParticipatedResponse {
-    @SerializedName("participated")
-    private boolean participated;
+    @SerializedName("available")
+    private boolean available;
 
     @SerializedName("challenge")
     private BaseChallenge challenge;
 
-    public boolean hasParticipatedInChallenge() { return participated; }
+    public boolean showChallengePopup() { return available; }
 
     public BaseChallenge getChallenge() { return challenge; }
 }

--- a/app/src/main/java/org/gem/indo/dooit/services/NotificationService.java
+++ b/app/src/main/java/org/gem/indo/dooit/services/NotificationService.java
@@ -208,7 +208,7 @@ public class NotificationService extends IntentService {
     protected void currentChallengeRetrieved(ChallengeParticipatedResponse challenge) {
         if (persisted.shouldNotify(NotificationType.CHALLENGE_AVAILABLE)
                 && persisted.getCurrentUser() != null
-                && !challenge.hasParticipatedInChallenge()) {
+                && challenge.showChallengePopup()) {
 
             Map<String, Object> params = DooitParamBuilder.create(this)
                     .setUser(persisted.getCurrentUser())

--- a/app/src/main/java/org/gem/indo/dooit/views/main/MainActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/MainActivity.java
@@ -151,7 +151,7 @@ public class MainActivity extends ImageActivity {
             @Override
             public void call(ChallengeParticipatedResponse response) {
                 if (response.getChallenge() != null) {
-                    if (!response.hasParticipatedInChallenge()) {
+                    if (response.showChallengePopup()) {
                         ChallengeLightboxFragment challengeLightboxFragment = ChallengeLightboxFragment.newInstance(response.getChallenge());
                         challengeLightboxFragment.show(getFragmentManager(), "challenge_available_lightbox");
                     }


### PR DESCRIPTION
Challenge pop ups on main activity will only fire if the user has at least one goal set and has not participated in the active challenge.

Challenge push notifications will only fire under the same conditions.