### PR TITLE
Bugfix/Standard Currency Format

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/views/helpers/activity/CurrencyHelper.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/helpers/activity/CurrencyHelper.java
@@ -6,6 +6,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Currency;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Created by wsche on 2016/11/23.
@@ -15,16 +16,25 @@ public class CurrencyHelper {
     public static double DEFAULT_VALUE = 0.0f;
     private static Locale indonesia = new Locale("in", "ID");
 
+    private static Pattern currencyFormat = Pattern.compile("^Rp[.]?\\s*(.+)$");
+
     public static String format(Object o) {
         try {
-            // Lock currency symbols to Indonesian Rupiah
-            return NumberFormat.getCurrencyInstance(indonesia).format(Double.valueOf(String.valueOf(o))) + ",-";
-            //return NumberFormat.getCurrencyInstance().format(Double.valueOf((String.valueOf(o))));
+            // Requested currency format is 'Rp. XX.XXX,-'
+            // Number formatter for Indonesian locale returns 'RpXX.XXX'
+            // Regex formats currency as requested
+
+            String indonesianFormat = NumberFormat.getCurrencyInstance(indonesia).format(Double.valueOf(String.valueOf(o)));
+            indonesianFormat = indonesianFormat.replaceFirst("^Rp[.]?\\s*(.+)(,-)?$", "Rp. $1,-");
+            return indonesianFormat;
+
+//            return NumberFormat.getCurrencyInstance(indonesia).format(Double.valueOf(String.valueOf(o)));
+//            return NumberFormat.getCurrencyInstance().format(Double.valueOf((String.valueOf(o))));
         } catch (Exception e) {
             Crashlytics.log("Error converting number to currency [" + String.valueOf(o) + "]");
             Crashlytics.logException(e);
         }
-        return NumberFormat.getCurrencyInstance().format(DEFAULT_VALUE) + ",-";
+        return NumberFormat.getCurrencyInstance().format(DEFAULT_VALUE);
     }
 
     public static String getCurrencySymbol() {

--- a/app/src/main/java/org/gem/indo/dooit/views/helpers/activity/CurrencyHelper.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/helpers/activity/CurrencyHelper.java
@@ -18,13 +18,13 @@ public class CurrencyHelper {
     public static String format(Object o) {
         try {
             // Lock currency symbols to Indonesian Rupiah
-            return NumberFormat.getCurrencyInstance(indonesia).format(Double.valueOf(String.valueOf(o)));
+            return NumberFormat.getCurrencyInstance(indonesia).format(Double.valueOf(String.valueOf(o))) + ",-";
             //return NumberFormat.getCurrencyInstance().format(Double.valueOf((String.valueOf(o))));
         } catch (Exception e) {
             Crashlytics.log("Error converting number to currency [" + String.valueOf(o) + "]");
             Crashlytics.logException(e);
         }
-        return NumberFormat.getCurrencyInstance().format(DEFAULT_VALUE);
+        return NumberFormat.getCurrencyInstance().format(DEFAULT_VALUE) + ",-";
     }
 
     public static String getCurrencySymbol() {

--- a/app/src/main/java/org/gem/indo/dooit/views/helpers/activity/CurrencyHelper.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/helpers/activity/CurrencyHelper.java
@@ -16,8 +16,6 @@ public class CurrencyHelper {
     public static double DEFAULT_VALUE = 0.0f;
     private static Locale indonesia = new Locale("in", "ID");
 
-    private static Pattern currencyFormat = Pattern.compile("^Rp[.]?\\s*(.+)$");
-
     public static String format(Object o) {
         try {
             // Requested currency format is 'Rp. XX.XXX,-'
@@ -28,8 +26,9 @@ public class CurrencyHelper {
             indonesianFormat = indonesianFormat.replaceFirst("^Rp[.]?\\s*(.+)(,-)?$", "Rp. $1,-");
             return indonesianFormat;
 
-//            return NumberFormat.getCurrencyInstance(indonesia).format(Double.valueOf(String.valueOf(o)));
-//            return NumberFormat.getCurrencyInstance().format(Double.valueOf((String.valueOf(o))));
+            // Old number formats that return Indonesian format and device format
+            //return NumberFormat.getCurrencyInstance(indonesia).format(Double.valueOf(String.valueOf(o)));
+            //return NumberFormat.getCurrencyInstance().format(Double.valueOf((String.valueOf(o))));
         } catch (Exception e) {
             Crashlytics.log("Error converting number to currency [" + String.valueOf(o) + "]");
             Crashlytics.logException(e);
@@ -44,7 +43,7 @@ public class CurrencyHelper {
     }
 
     public static char getSeperator() {
-        return ((DecimalFormat) NumberFormat.getCurrencyInstance(new Locale("in", "ID"))).getDecimalFormatSymbols().getGroupingSeparator();
+        return ((DecimalFormat) NumberFormat.getCurrencyInstance(indonesia)).getDecimalFormatSymbols().getGroupingSeparator();
         //return ((DecimalFormat) NumberFormat.getCurrencyInstance()).getDecimalFormatSymbols().getGroupingSeparator();
     }
 }


### PR DESCRIPTION
The Android currency format for Indonesian locale returns currency in the following format: `RpXX.XXX'.
It has been requested that currency is shown in this format: `Rp. XX.XXX,-`.

The RegEx will perform this formatting.