### PR TITLE
Prevent IllegalStateException in challenge popup

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/views/main/MainActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/MainActivity.java
@@ -153,8 +153,10 @@ public class MainActivity extends ImageActivity {
                 if (response.getChallenge() != null) {
                     if (!response.hasParticipatedInChallenge()) {
                         ChallengeLightboxFragment challengeLightboxFragment = ChallengeLightboxFragment.newInstance(response.getChallenge());
-                        if (getFragmentManager() != null) {
+                        try {
                             challengeLightboxFragment.show(getFragmentManager(), "challenge_available_lightbox");
+                        } catch (IllegalStateException e) {
+                            // Fragment manager is unavailable so do nothing
                         }
                     }
                 }

--- a/app/src/main/java/org/gem/indo/dooit/views/main/MainActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/MainActivity.java
@@ -153,7 +153,9 @@ public class MainActivity extends ImageActivity {
                 if (response.getChallenge() != null) {
                     if (!response.hasParticipatedInChallenge()) {
                         ChallengeLightboxFragment challengeLightboxFragment = ChallengeLightboxFragment.newInstance(response.getChallenge());
-                        challengeLightboxFragment.show(getFragmentManager(), "challenge_available_lightbox");
+                        if (getFragmentManager() != null) {
+                            challengeLightboxFragment.show(getFragmentManager(), "challenge_available_lightbox");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Don't show the challenge popup if the FragmentManager cannot be found, will fix a crash.