### PR TITLE
Registration Issues

### DIFF
--- a/app/release-notes.txt
+++ b/app/release-notes.txt
@@ -1,6 +1,6 @@
 
-1.2.4
+1.2.5
 
-- Weekly calculations correctly round down
-- Fixed typos in Indonesian strings
-- Added logging to registration to trace potential issues
+- Forcing HTTPS connections to use TLSv1.2
+- Fixed Null Pointer Exception when cancelling camera or gallery
+- More aggressively recycling Bitmaps to help alleviate memory issues around manipulating images

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,6 +103,7 @@
         <activity
             android:name=".views.onboarding.ChangeSecurityQuestionActivity"
             android:label="@string/title_activity_change_security_question"
+            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar" />
 
         <provider

--- a/app/src/main/java/org/gem/indo/dooit/DooitApplication.java
+++ b/app/src/main/java/org/gem/indo/dooit/DooitApplication.java
@@ -1,6 +1,5 @@
 package org.gem.indo.dooit;
 
-import android.os.Build;
 import android.support.multidex.MultiDexApplication;
 import android.util.Log;
 
@@ -17,27 +16,18 @@ import org.gem.indo.dooit.dagger.DooitComponent;
 import org.gem.indo.dooit.dagger.DooitModule;
 import org.gem.indo.dooit.helpers.Persisted;
 import org.gem.indo.dooit.helpers.Tls12SocketFactory;
-import org.gem.indo.dooit.helpers.crashlytics.CrashlyticsHelper;
 
 import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.SSLSocketFactory;
 
 import io.fabric.sdk.android.Fabric;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
 import okhttp3.CipherSuite;
-import okhttp3.ConnectionSpec;
 import okhttp3.Handshake;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -91,8 +81,7 @@ public class DooitApplication extends MultiDexApplication {
                     requestBuilder.addHeader("Authorization", "Token " + persisted.getToken());
 
                 Request request = requestBuilder.build();
-
-                /*Response response = chain.proceed(request);
+                Response response = chain.proceed(request);
                 if (response != null) {
                     Handshake handshake = response.handshake();
                     if (handshake != null) {
@@ -100,54 +89,16 @@ public class DooitApplication extends MultiDexApplication {
                         final TlsVersion tlsVersion = handshake.tlsVersion();
                         Log.v("DooitApplication", "TLS: " + tlsVersion + ", CipherSuite: " + cipherSuite);
                     }
-                }*/
+                }
                 return chain.proceed(request);
             }
         });
 
+        Tls12SocketFactory.forceTLS(httpClient);
+
         httpClient.connectTimeout(10, TimeUnit.SECONDS)
                 .writeTimeout(10, TimeUnit.SECONDS)
                 .readTimeout(30, TimeUnit.SECONDS);
-
-        // https://github.com/square/okhttp/issues/2372
-        // Prevent fallback to SSLv3 on Old Android Devices. Attempt to force TLSv1.2
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
-            try {
-                // SSLv3, TLSv1, TLSv1.1, TLSv1.2 etc.
-                // Log which protocols are available
-                CrashlyticsHelper.log("SSL Default Protocols", "onCreate",
-                        Arrays.toString(SSLContext.getDefault()
-                                .getDefaultSSLParameters().getProtocols()));
-                SSLParameters sslParameters = SSLContext.getDefault()
-                        .getSupportedSSLParameters();
-                CrashlyticsHelper.log("SSL Supported Protocols", "onCreate",
-                        Arrays.toString(sslParameters.getProtocols()));
-
-                // Scan for TLSv1.2 support
-                boolean found = false;
-                for (String protocol : sslParameters.getProtocols()) {
-                    if (protocol.equals(TlsVersion.TLS_1_2.javaName())) {
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (found) {
-                    SSLContext sc = SSLContext.getInstance(TlsVersion.TLS_1_2.javaName());
-                    sc.init(null, null, null);
-                    SSLSocketFactory factory = new Tls12SocketFactory(sc.getSocketFactory());
-                    httpClient.sslSocketFactory(factory);
-                    httpClient.connectionSpecs(Collections.singletonList(new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                            .tlsVersions(TlsVersion.TLS_1_2)
-                            .cipherSuites(Tls12SocketFactory.CIPHER_SUITS)
-                            .build()));
-                } else {
-                    CrashlyticsHelper.log("TLS Support:", "onCreate", "TLSv1.2 not supported!");
-                }
-            } catch (NoSuchAlgorithmException | KeyManagementException e) {
-                CrashlyticsHelper.logException(e);
-            }
-        }
 
         // Fresco
         Set<RequestListener> requestListeners = new HashSet<>();

--- a/app/src/main/java/org/gem/indo/dooit/DooitApplication.java
+++ b/app/src/main/java/org/gem/indo/dooit/DooitApplication.java
@@ -1,6 +1,8 @@
 package org.gem.indo.dooit;
 
+import android.os.Build;
 import android.support.multidex.MultiDexApplication;
+import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
 import com.facebook.common.logging.FLog;
@@ -14,21 +16,34 @@ import org.gem.indo.dooit.dagger.DaggerDooitComponent;
 import org.gem.indo.dooit.dagger.DooitComponent;
 import org.gem.indo.dooit.dagger.DooitModule;
 import org.gem.indo.dooit.helpers.Persisted;
+import org.gem.indo.dooit.helpers.Tls12SocketFactory;
+import org.gem.indo.dooit.helpers.crashlytics.CrashlyticsHelper;
 
 import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
 
 import io.fabric.sdk.android.Fabric;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
+import okhttp3.CipherSuite;
+import okhttp3.ConnectionSpec;
+import okhttp3.Handshake;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.TlsVersion;
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
 
 /**
@@ -76,13 +91,63 @@ public class DooitApplication extends MultiDexApplication {
                     requestBuilder.addHeader("Authorization", "Token " + persisted.getToken());
 
                 Request request = requestBuilder.build();
-                return chain.proceed(request);
+
+                Response response = chain.proceed(request);
+                if (response != null) {
+                    Handshake handshake = response.handshake();
+                    if (handshake != null) {
+                        final CipherSuite cipherSuite = handshake.cipherSuite();
+                        final TlsVersion tlsVersion = handshake.tlsVersion();
+                        Log.v("DooitApplication", "TLS: " + tlsVersion + ", CipherSuite: " + cipherSuite);
+                    }
+                }
+                return response;
             }
         });
 
         httpClient.connectTimeout(10, TimeUnit.SECONDS)
                 .writeTimeout(10, TimeUnit.SECONDS)
                 .readTimeout(30, TimeUnit.SECONDS);
+
+        // https://github.com/square/okhttp/issues/2372
+        // Prevent fallback to SSLv3 on Old Android Devices. Attempt to force TLSv1.2
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
+            try {
+                // SSLv3, TLSv1, TLSv1.1, TLSv1.2 etc.
+                // Log which protocols are available
+                CrashlyticsHelper.log("SSL Default Protocols", "onCreate",
+                        Arrays.toString(SSLContext.getDefault()
+                                .getDefaultSSLParameters().getProtocols()));
+                SSLParameters sslParameters = SSLContext.getDefault()
+                        .getSupportedSSLParameters();
+                CrashlyticsHelper.log("SSL Supported Protocols", "onCreate",
+                        Arrays.toString(sslParameters.getProtocols()));
+
+                // Scan for TLSv1.2 support
+                boolean found = false;
+                for (String protocol : sslParameters.getProtocols()) {
+                    if (protocol.equals(TlsVersion.TLS_1_2.javaName())) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found) {
+                    SSLContext sc = SSLContext.getInstance(TlsVersion.TLS_1_2.javaName());
+                    sc.init(null, null, null);
+                    SSLSocketFactory factory = new Tls12SocketFactory(sc.getSocketFactory());
+                    httpClient.sslSocketFactory(factory);
+                    httpClient.connectionSpecs(Collections.singletonList(new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                            .tlsVersions(TlsVersion.TLS_1_2)
+                            .cipherSuites(Tls12SocketFactory.CIPHER_SUITS)
+                            .build()));
+                } else {
+                    CrashlyticsHelper.log("TLS Support:", "onCreate", "TLSv1.2 not supported!");
+                }
+            } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                CrashlyticsHelper.logException(e);
+            }
+        }
 
         // Fresco
         Set<RequestListener> requestListeners = new HashSet<>();
@@ -104,5 +169,5 @@ public class DooitApplication extends MultiDexApplication {
         );
     }
 
-    
+
 }

--- a/app/src/main/java/org/gem/indo/dooit/DooitApplication.java
+++ b/app/src/main/java/org/gem/indo/dooit/DooitApplication.java
@@ -92,7 +92,7 @@ public class DooitApplication extends MultiDexApplication {
 
                 Request request = requestBuilder.build();
 
-                Response response = chain.proceed(request);
+                /*Response response = chain.proceed(request);
                 if (response != null) {
                     Handshake handshake = response.handshake();
                     if (handshake != null) {
@@ -100,8 +100,8 @@ public class DooitApplication extends MultiDexApplication {
                         final TlsVersion tlsVersion = handshake.tlsVersion();
                         Log.v("DooitApplication", "TLS: " + tlsVersion + ", CipherSuite: " + cipherSuite);
                     }
-                }
-                return response;
+                }*/
+                return chain.proceed(request);
             }
         });
 

--- a/app/src/main/java/org/gem/indo/dooit/api/managers/DooitManager.java
+++ b/app/src/main/java/org/gem/indo/dooit/api/managers/DooitManager.java
@@ -23,6 +23,7 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -110,6 +111,10 @@ public abstract class DooitManager {
             }
         });
         httpClient.addInterceptor(logging);
+
+        httpClient.connectTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS);
 
         Tls12SocketFactory.forceTLS(httpClient);
 

--- a/app/src/main/java/org/gem/indo/dooit/api/managers/DooitManager.java
+++ b/app/src/main/java/org/gem/indo/dooit/api/managers/DooitManager.java
@@ -16,6 +16,7 @@ import org.gem.indo.dooit.api.serializers.LocalDateSerializer;
 import org.gem.indo.dooit.helpers.DooitSharedPreferences;
 import org.gem.indo.dooit.helpers.LanguageCodeHelper;
 import org.gem.indo.dooit.helpers.Persisted;
+import org.gem.indo.dooit.helpers.Tls12SocketFactory;
 import org.gem.indo.dooit.helpers.auth.InvalidTokenHandler;
 import org.gem.indo.dooit.helpers.auth.InvalidTokenRedirectHelper;
 import org.joda.time.DateTime;
@@ -25,10 +26,13 @@ import java.io.IOException;
 
 import javax.inject.Inject;
 
+import okhttp3.CipherSuite;
+import okhttp3.Handshake;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.TlsVersion;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.HttpException;
@@ -92,10 +96,22 @@ public abstract class DooitManager {
                 if (response != null && response.code() == 403) {
                     invalidTokenRedirectHelper.redirectIfNeeded(invalidTokenHandler, context);
                 }
+
+                if (response != null) {
+                    Handshake handshake = response.handshake();
+                    if (handshake != null) {
+                        final CipherSuite cipherSuite = handshake.cipherSuite();
+                        final TlsVersion tlsVersion = handshake.tlsVersion();
+                        Log.v("DooitApplication", "TLS: " + tlsVersion + ", CipherSuite: " + cipherSuite);
+                    }
+                }
+
                 return response;
             }
         });
         httpClient.addInterceptor(logging);
+
+        Tls12SocketFactory.forceTLS(httpClient);
 
         OkHttpClient client = httpClient.build();
 

--- a/app/src/main/java/org/gem/indo/dooit/controllers/goal/GoalAddController.java
+++ b/app/src/main/java/org/gem/indo/dooit/controllers/goal/GoalAddController.java
@@ -129,7 +129,7 @@ public class GoalAddController extends GoalBotController {
             persisted.saveConvoGoal(botType, goal);
         } catch (IllegalArgumentException e) {
             // Logging for infinite double error
-            CrashlyticsHelper.log(TAG, "on Answer Input (addGoal): ", "goal start date: " + goal.getStartDate() +
+            CrashlyticsHelper.log(TAG, "onAnswerInput", "(addGoal) goal start date: " + goal.getStartDate() +
                     " Target amount: " + goal.getTarget() + " Goal name: " + goal.getName() +
                     " Goal Weekly Target: " + goal.getWeeklyTarget());
 
@@ -180,7 +180,7 @@ public class GoalAddController extends GoalBotController {
             CrashlyticsHelper.log(TAG, "doPopulate", "User inputted a weekly target");
             goal.setWeeklyTarget(Double.parseDouble(answerLog.get("weeklySaveAmount").getValue()));
         }
-        CrashlyticsHelper.log(TAG, "do Populate (addGoal): ", "goal start date: " + goal.getStartDate() +
+        CrashlyticsHelper.log(TAG, "doPopulate", "(addGoal) goal start date: " + goal.getStartDate() +
                 " Target amount: " + goal.getTarget() + " Goal name: " + goal.getName());
 
         // User has existing savings
@@ -266,8 +266,8 @@ public class GoalAddController extends GoalBotController {
                     }
                 });
 
-                CrashlyticsHelper.log(this.getClass().getSimpleName(), "doCreate (BOT) : ",
-                        "MediaURI.getPath : context: " + context + " uri: " + uri + "MimeType: " + mimetype);
+                CrashlyticsHelper.log(this.getClass().getSimpleName(), "doCreate",
+                        "(BOT) MediaURI.getPath : context: " + context + " uri: " + uri + "MimeType: " + mimetype);
             } catch (NullPointerException nullException) {
                 CrashlyticsHelper.logException(nullException);
             }

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Tls12SocketFactory.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Tls12SocketFactory.java
@@ -1,0 +1,99 @@
+package org.gem.indo.dooit.helpers;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import okhttp3.CipherSuite;
+
+/**
+ * Created by Wimpie Victor on 2017/09/04.
+ *
+ * @link https://github.com/square/okhttp/issues/2372
+ * <p>
+ * Enables TLS v1.2 when creating SSLSockets.
+ * <p/>
+ * For some reason, android supports TLS v1.2 from API 16, but enables it by
+ * default only from API 20.
+ * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+ * @see SSLSocketFactory
+ */
+public class Tls12SocketFactory extends SSLSocketFactory {
+    private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+    // From okhttp3.ConnectionSpec
+    // This is a subset of the cipher suites supported in Chrome 46, current as of 2015-11-05.
+    // All of these suites are available on Android 5.0; earlier releases support a subset of
+    // these suites. https://github.com/square/okhttp/issues/330
+    public static final CipherSuite[] CIPHER_SUITS = {
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+
+            // Note that the following cipher suites are all on HTTP/2's bad cipher suites list. We'll
+            // continue to include them until better suites are commonly available. For example, none
+            // of the better cipher suites listed above shipped with Android 4.4 or Java 7.
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+    };
+
+    private final SSLSocketFactory delegate;
+
+    public Tls12SocketFactory(SSLSocketFactory base) {
+        this.delegate = base;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return patch(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return patch(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket patch(Socket s) {
+        if (s instanceof SSLSocket) {
+            ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+        }
+        return s;
+    }
+}

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Tls12SocketFactory.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Tls12SocketFactory.java
@@ -1,14 +1,28 @@
 package org.gem.indo.dooit.helpers;
 
+import android.os.Build;
+
+import org.gem.indo.dooit.helpers.crashlytics.CrashlyticsHelper;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 import okhttp3.CipherSuite;
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
 
 /**
  * Created by Wimpie Victor on 2017/09/04.
@@ -29,24 +43,24 @@ public class Tls12SocketFactory extends SSLSocketFactory {
     // This is a subset of the cipher suites supported in Chrome 46, current as of 2015-11-05.
     // All of these suites are available on Android 5.0; earlier releases support a subset of
     // these suites. https://github.com/square/okhttp/issues/330
-    public static final CipherSuite[] CIPHER_SUITS = {
-            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+    public static final String[] CIPHER_SUITS = {
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256.javaName(),
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.javaName(),
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256.javaName(),
 
             // Note that the following cipher suites are all on HTTP/2's bad cipher suites list. We'll
             // continue to include them until better suites are commonly available. For example, none
             // of the better cipher suites listed above shipped with Android 4.4 or Java 7.
-            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-            CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
-            CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
-            CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
-            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
-            CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA.javaName(),
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA.javaName(),
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA.javaName(),
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA.javaName(),
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA.javaName(),
+            CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA.javaName(),
+            CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256.javaName(),
+            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA.javaName(),
+            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA.javaName(),
+            CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA.javaName(),
     };
 
     private final SSLSocketFactory delegate;
@@ -93,7 +107,61 @@ public class Tls12SocketFactory extends SSLSocketFactory {
     private Socket patch(Socket s) {
         if (s instanceof SSLSocket) {
             ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+            ((SSLSocket) s).setEnabledCipherSuites(CIPHER_SUITS);
         }
         return s;
+    }
+
+    /**
+     * Prevent fallback to SSLv3 on old Android devices. Attempt to force TLSv1.2.
+     * <p>
+     * https://github.com/square/okhttp/issues/2372
+     *
+     * @param httpClient
+     */
+    public static void forceTLS(OkHttpClient.Builder httpClient) {
+
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
+            try {
+                // SSLv3, TLSv1, TLSv1.1, TLSv1.2 etc.
+                // Log which protocols are available
+                CrashlyticsHelper.log("SSL Default Protocols", "onCreate",
+                        Arrays.toString(SSLContext.getDefault()
+                                .getDefaultSSLParameters().getProtocols()));
+                SSLParameters sslParameters = SSLContext.getDefault()
+                        .getSupportedSSLParameters();
+                CrashlyticsHelper.log("SSL Supported Protocols", "onCreate",
+                        Arrays.toString(sslParameters.getProtocols()));
+
+                // Scan for TLSv1.2 support
+                boolean found = false;
+                for (String protocol : sslParameters.getProtocols()) {
+                    if (protocol.equals(TlsVersion.TLS_1_2.javaName())) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found) {
+                    SSLContext sc = SSLContext.getInstance(TlsVersion.TLS_1_2.javaName());
+                    sc.init(null, null, null);
+                    SSLSocketFactory factory = new Tls12SocketFactory(sc.getSocketFactory());
+                    httpClient.sslSocketFactory(factory);
+
+                    List<ConnectionSpec> specs = new ArrayList<>();
+                    specs.add(new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                            .tlsVersions(TlsVersion.TLS_1_2)
+                            .cipherSuites(Tls12SocketFactory.CIPHER_SUITS)
+                            .build());
+                    specs.add(ConnectionSpec.CLEARTEXT); // HTTP Fallback
+
+                    httpClient.connectionSpecs(specs);
+                } else {
+                    CrashlyticsHelper.log("TLS Support:", "onCreate", "TLSv1.2 not supported!");
+                }
+            } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                CrashlyticsHelper.logException(e);
+            }
+        }
     }
 }

--- a/app/src/main/java/org/gem/indo/dooit/helpers/crashlytics/CrashlyticsHelper.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/crashlytics/CrashlyticsHelper.java
@@ -14,7 +14,7 @@ public class CrashlyticsHelper{
 
     public static void log(String TAG, String methodName, String message) {
         if (!BuildConfig.DEBUG)
-            Crashlytics.log(Log.DEBUG, TAG + '.' + methodName, message);
+            Crashlytics.log(Log.DEBUG, TAG + '.' + methodName + ":", message);
     }
 
     public static void logException(Throwable e){

--- a/app/src/main/java/org/gem/indo/dooit/helpers/images/ImageActivityAsyncTaskResult.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/images/ImageActivityAsyncTaskResult.java
@@ -8,8 +8,8 @@ import android.net.Uri;
 
 public class ImageActivityAsyncTaskResult {
 
-    Uri imageUri;
-    String imagePath;
+    final private Uri imageUri;
+    final private String imagePath;
 
     public ImageActivityAsyncTaskResult(Uri imageUri, String imagePath) {
         this.imageUri = imageUri;

--- a/app/src/main/java/org/gem/indo/dooit/helpers/images/ImageScaler.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/images/ImageScaler.java
@@ -29,9 +29,8 @@ public class ImageScaler {
         }
 
         Bitmap out = Bitmap.createScaledBitmap(bitmap, width, height, true);
-        if (!bitmap.isRecycled() && !out.sameAs(bitmap)) {
+        if (!bitmap.isRecycled() && !out.sameAs(bitmap))
             bitmap.recycle();
-        }
         return out;
     }
 }

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -344,6 +344,8 @@ public abstract class ImageActivity extends DooitActivity {
      * URI Permissions must be revoked, or they will persisted until the device is restarted.
      */
     private void revokeCameraPermissions() {
+        if (imageUri == null)
+            return;
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT)
             revokeUriPermission(imageUri,
                     Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -241,6 +241,7 @@ public abstract class ImageActivity extends DooitActivity {
 
             //Here the image is scaled to an acceptable size
             bitmap = ImageScaler.scale(bitmap, maxImageWidth, maxImageHeight);
+            System.gc();
             //file is written out
             bitmap.compress(Bitmap.CompressFormat.JPEG, 80, outStream);
 
@@ -382,9 +383,8 @@ public abstract class ImageActivity extends DooitActivity {
                         ContentResolver cR = ImageActivity.this.getContentResolver();
                         Bitmap bitmap = (Bitmap) data.getExtras().get("data");
 
-                        System.gc();
-
                         bitmap = checkScreenOrientation(imagePath, bitmap, requestCodes);
+                        System.gc();
 
                         Log.d("IMAGE_TESTS", "Bitmap size : " + bitmap.getByteCount());
                         imageUri = Uri.parse(MediaStore.Images.Media.insertImage(cR, bitmap, "", ""));

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -188,6 +188,28 @@ public abstract class ImageActivity extends DooitActivity {
     }
 
     /**
+     * Bitmap and returns the downscaling factor (only sampling every nth pixel) to fit into
+     * max width/height.
+     *
+     * Does not require full bitmap -- decoding just the bounds is sufficient.
+     *
+     * @param bmp  The bitmap to measure
+     * @return int Sample factor.
+     */
+    private int calcSampleSize(Bitmap bmp) {
+        if (bmp != null) {
+            float widthRatio = bmp.getWidth() / maxImageWidth;
+            float heightRatio = bmp.getHeight() / maxImageWidth;
+            float largestDimRatio = (widthRatio >= heightRatio) ? widthRatio : heightRatio;
+            if (largestDimRatio >= 1) {
+                return (int) largestDimRatio;
+            }
+        }
+
+        return 1;
+    }
+
+    /**
      * Loads the image file stored in imagePath, saves a new downscaled version, and resets imageUri
      * and imagePath.
      */
@@ -202,14 +224,7 @@ public abstract class ImageActivity extends DooitActivity {
         BitmapFactory.Options boundsOptions = new BitmapFactory.Options();
         boundsOptions.inJustDecodeBounds = true;
         Bitmap bounds = BitmapFactory.decodeFile(imagePath, boundsOptions);
-        if (bounds != null) {
-            float widthRatio = bounds.getWidth() / maxImageWidth;
-            float heightRatio = bounds.getHeight() / maxImageWidth;
-            float largestDimRatio = (widthRatio >= heightRatio) ? widthRatio : heightRatio;
-            if (largestDimRatio >= 1) {
-                options.inSampleSize = (int) largestDimRatio;
-            }
-        }
+        options.inSampleSize = calcSampleSize(bounds);
 
         try {
             File downscaledFile = createImageFile();

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -95,6 +95,7 @@ public abstract class ImageActivity extends DooitActivity {
             return out;
         } catch (OutOfMemoryError e) {
             Log.e(TAG, String.format("Rotation failed (dim=%dx%d).", source.getWidth(), source.getHeight()), e);
+            CrashlyticsHelper.logException(e);
             return source;
         }
     }
@@ -228,16 +229,16 @@ public abstract class ImageActivity extends DooitActivity {
     /**
      * Bitmap and returns the downscaling factor (only sampling every nth pixel) to fit into
      * max width/height.
-     *
+     * <p>
      * Does not require full bitmap -- decoding just the bounds is sufficient.
      *
-     * @param bmp  The bitmap to measure
+     * @param bmp The bitmap to measure
      * @return int Sample factor.
      */
-    private int calcSampleSize(Bitmap bmp) {
+    static private int calcSampleSize(Bitmap bmp) {
         if (bmp != null) {
-            float widthRatio = bmp.getWidth() / maxImageWidth;
-            float heightRatio = bmp.getHeight() / maxImageWidth;
+            float widthRatio = bmp.getWidth() / MAX_IMAGE_WIDTH;
+            float heightRatio = bmp.getHeight() / MAX_IMAGE_HEIGHT;
             float largestDimRatio = (widthRatio >= heightRatio) ? widthRatio : heightRatio;
             if (largestDimRatio >= 1) {
                 return (int) largestDimRatio;
@@ -263,7 +264,7 @@ public abstract class ImageActivity extends DooitActivity {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inPreferredConfig = Bitmap.Config.ARGB_8888;
 
-      {
+        {
             // Don't load every pixel if image is too large
             BitmapFactory.Options boundsOptions = new BitmapFactory.Options();
             boundsOptions.inJustDecodeBounds = true;
@@ -274,7 +275,7 @@ public abstract class ImageActivity extends DooitActivity {
                     bounds.recycle();
                     System.gc();
                 }
-           
+
         }
 
         try {

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -287,10 +287,8 @@ public abstract class ImageActivity extends DooitActivity {
                 default:
                     break;
             }
-        } catch (IllegalArgumentException ia) {
+        } catch (IllegalArgumentException | IOException ia) {
             // If image path is null, IllegalArgumentException is thrown
-        } catch (IOException io) {
-
         }
         return bitmap;
     }
@@ -334,10 +332,6 @@ public abstract class ImageActivity extends DooitActivity {
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT)
             revokeUriPermission(imageUri,
                     Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
-    }
-
-    protected Uri getImageUri() {
-        return imageUri;
     }
 
     /**

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -257,7 +257,7 @@ public abstract class ImageActivity extends DooitActivity {
         } catch (IOException e) {
             Toast.makeText(ImageActivity.this, "Unable to do image rotation", Toast.LENGTH_LONG).show();
             Log.e(TAG, "Unable to create temporary downscaled image file", e);
-            CrashlyticsHelper.log(this.getClass().getSimpleName(), " processImage : ", "an IOException");
+            CrashlyticsHelper.log(this.getClass().getSimpleName(), "processImage", "an IOException");
         } finally {
             try {
                 if (outStream != null)
@@ -400,7 +400,7 @@ public abstract class ImageActivity extends DooitActivity {
                 // MediaUriHelper does not work when uri points to temp image file
                 try {
                     imagePath = MediaUriHelper.getPath(ImageActivity.this, imageUri);
-                    CrashlyticsHelper.log(this.getClass().getSimpleName(), "handleImageResult : ",
+                    CrashlyticsHelper.log(this.getClass().getSimpleName(), "handleImageResult",
                             "Context: " + this + " imageUri :" + imageUri);
                 } catch (NullPointerException nullException) {
                     CrashlyticsHelper.logException(nullException);

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -421,6 +421,10 @@ public abstract class ImageActivity extends DooitActivity {
      */
     protected abstract void onImageResult(String mediaType, Uri imageUri, String imagePath);
 
+    /**
+     * Image processing is run on a background thread to allow the garbage collector to run. When
+     * done on the UI thread, the garbage collector waits for the UI thread to yield.
+     */
     private class HandleImage extends AsyncTask<Object, Integer, ImageActivityAsyncTaskResult> {
 
         /**

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -62,12 +62,16 @@ public abstract class ImageActivity extends DooitActivity {
     public static Bitmap rotateImage(Bitmap source, float angle) {
         Matrix matrix = new Matrix();
         matrix.postRotate(angle);
-        Bitmap out = Bitmap.createBitmap(source, 0, 0, source.getWidth(), source.getHeight(),
-                matrix, true);
-        if (!source.isRecycled() && !out.sameAs(source)) {
-            source.recycle();
+        try {
+            Bitmap out = Bitmap.createBitmap(source, 0, 0, source.getWidth(), source.getHeight(),
+                    matrix, true);
+            if (!source.isRecycled() && !out.sameAs(source)) {
+                source.recycle();
+            }
+            return out;
+        } catch (OutOfMemoryError e) {
+            return source;
         }
-        return out;
     }
 
     private void resetImageState() {

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -322,6 +322,7 @@ public abstract class ImageActivity extends DooitActivity {
                     outStream.close();
             } catch (IOException e) {
                 Log.e(TAG, "Failed to close outstream", e);
+                CrashlyticsHelper.logException(e);
             }
         }
 

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -70,6 +70,7 @@ public abstract class ImageActivity extends DooitActivity {
             }
             return out;
         } catch (OutOfMemoryError e) {
+            Log.d(TAG, "Rotation failed - out of memory.");
             return source;
         }
     }

--- a/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/ImageActivity.java
@@ -70,7 +70,7 @@ public abstract class ImageActivity extends DooitActivity {
             }
             return out;
         } catch (OutOfMemoryError e) {
-            Log.d(TAG, "Rotation failed - out of memory.");
+            Log.e(TAG, String.format("Rotation failed (dim=%dx%d).", source.getWidth(), source.getHeight()), e);
             return source;
         }
     }

--- a/app/src/main/java/org/gem/indo/dooit/views/main/MainActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/MainActivity.java
@@ -439,7 +439,7 @@ public class MainActivity extends ImageActivity {
      */
     @Override
     protected void onImageResult(String mediaType, Uri imageUri, String imagePath) {
-        CrashlyticsHelper.log(this.getClass().getSimpleName(), "OnImageResult : ", "successful image result (settings)");
+        CrashlyticsHelper.log(this.getClass().getSimpleName(), "OnImageResult", "successful image result (settings)");
         if (imageSelectedListener != null) {
             imageSelectedListener.handleSelectedImage(mediaType, imageUri, imagePath);
         }

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/BotFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/BotFragment.java
@@ -550,12 +550,12 @@ public class BotFragment extends MainFragment implements HashtagView.TagsClickLi
             model.setType(BotMessageType.TEXT);
             getBotAdapter().removeItem(model);
             getBotAdapter().addItem(model);
-            CrashlyticsHelper.log(this.getClass().getSimpleName(), "onItemClicked: ", "model changed: " + model.toString());
+            CrashlyticsHelper.log(this.getClass().getSimpleName(), "onItemClicked", "model changed: " + model.toString());
         }
 
         if (shouldAdd(answer)) {
             getBotAdapter().addItem(answer);
-            CrashlyticsHelper.log(this.getClass().getSimpleName(), "onItemClicked: ", "adding to conversation: " + answer.toString());
+            CrashlyticsHelper.log(this.getClass().getSimpleName(), "onItemClicked", "adding to conversation: " + answer.toString());
         }
 
         if (answer.hasInputKey() && hasController())
@@ -727,7 +727,7 @@ public class BotFragment extends MainFragment implements HashtagView.TagsClickLi
             finishConversation();
         } else {
             addAnswerOptions(node);
-            CrashlyticsHelper.log(this.getClass().getSimpleName(), "checkEndOrAddAnswers: ", "data set: " + getBotAdapter().getDataSet());
+            CrashlyticsHelper.log(this.getClass().getSimpleName(), "checkEndOrAddAnswers", "data set: " + getBotAdapter().getDataSet());
         }
     }
 
@@ -824,7 +824,7 @@ public class BotFragment extends MainFragment implements HashtagView.TagsClickLi
         }
         answer.setProcessedText(args.process(answer.values.getRawMap()));
         CrashlyticsHelper.log(this.getClass().getSimpleName(),
-                "processText: ", "Processed answer : " + answer.toString());
+                "processText", "Processed answer : " + answer.toString());
     }
 
     private void clearAnswerView() {

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/adapters/BotAdapter.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/adapters/BotAdapter.java
@@ -87,7 +87,7 @@ public class BotAdapter extends RecyclerView.Adapter<BaseBotViewHolder> {
             case TIP:
                 return new TipBotViewHolder(LayoutInflater.from(context).inflate(R.layout.item_view_bot_tip, parent, false), this, tagsClickListener);
             case GOALINFO:
-                CrashlyticsHelper.log(this.getClass().getSimpleName(), "onCreateViewHolder: ", "from(context) : " + context + "case: " + GOALINFO);
+                CrashlyticsHelper.log(this.getClass().getSimpleName(), "onCreateViewHolder", "from(context) : " + context + "case: " + GOALINFO);
                 return new GoalInfoViewHolder(LayoutInflater.from(context).inflate(R.layout.item_view_bot_goal_info, parent, false), this);
             case BADGE:
                 return new BadgeViewHolder(LayoutInflater.from(context).inflate(R.layout.item_view_bot_badge, parent, false), this);

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerImageSelectViewHolder.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerImageSelectViewHolder.java
@@ -117,7 +117,7 @@ public class AnswerImageSelectViewHolder extends BaseBotViewHolder<Answer>
             tagsClickListener.onItemClicked(answer);
         }
 
-        CrashlyticsHelper.log(this.getClass().getSimpleName(), "uploadImage: ", "upload an image from bot");
+        CrashlyticsHelper.log(this.getClass().getSimpleName(), "uploadImage", "upload an image from bot");
     }
 
     public Context getContext() {

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerImageViewHolder.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerImageViewHolder.java
@@ -35,7 +35,7 @@ public class AnswerImageViewHolder extends BaseBotViewHolder<Answer> {
     public void populate(Answer model) {
         super.populate(model);
         simpleDraweeView.setImageURI(Uri.parse(model.getValue()));
-        CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate (Image): ", "URI: " + dataModel.getValue());
+        CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate", "(Image) URI: " + dataModel.getValue());
     }
 
     @Override

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerInlineDateEditViewHolder.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerInlineDateEditViewHolder.java
@@ -86,7 +86,7 @@ public class AnswerInlineDateEditViewHolder extends BaseBotViewHolder<Answer> {
                         inputAnswer.setNext(dataModel.getNextOnFinish());
                         inputAnswer.setType(BotMessageType.getValueOf(dataModel.getTypeOnFinish()));
                         tagsClickListener.onItemClicked(inputAnswer);
-                        CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate (dateEdit): ", "New date: " + inputAnswer.getValue());
+                        CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate", "(dateEdit) New date: " + inputAnswer.getValue());
                     }
                 });
             }

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerInlineNumberEditViewHolder.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerInlineNumberEditViewHolder.java
@@ -94,7 +94,7 @@ public class AnswerInlineNumberEditViewHolder extends BaseBotViewHolder<Answer> 
                     inputAnswer.setType(BotMessageType.getValueOf(dataModel.getTypeOnFinish()));
                     inputAnswer.setInputKey(dataModel.getInputKey());
                     tagsClickListener.onItemClicked(inputAnswer);
-                    CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate (numberedit): ", "number: " + inputAnswer.getValue());
+                    CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate", "(numberedit) number: " + inputAnswer.getValue());
                     return true;
                 }
                 return false;

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerInlineTextEditViewHolder.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerInlineTextEditViewHolder.java
@@ -74,7 +74,7 @@ public class AnswerInlineTextEditViewHolder extends BaseBotViewHolder<Answer> {
                     inputAnswer.setType(BotMessageType.getValueOf(dataModel.getTypeOnFinish()));
                     inputAnswer.setParentName(dataModel.getParentName());
                     tagsClickListener.onItemClicked(inputAnswer);
-                    CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate (textedit): ", "text: " + inputAnswer.getValue());
+                    CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate", "(textedit) text: " + inputAnswer.getValue());
                     return true;
                 }
                 return false;

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerTextCurrencyViewHolder.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerTextCurrencyViewHolder.java
@@ -36,7 +36,7 @@ public class AnswerTextCurrencyViewHolder extends BaseBotViewHolder<Answer> {
     public void populate(Answer model) {
         super.populate(model);
         textView.setText(CurrencyHelper.format(dataModel.getValue()));
-        CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate (TextCurrencyEdit): ", "Amount: " + dataModel.getValue());
+        CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate", "(TextCurrencyEdit) Amount: " + dataModel.getValue());
     }
 
     @Override

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengePictureFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/challenge/fragments/ChallengePictureFragment.java
@@ -300,7 +300,7 @@ public class ChallengePictureFragment extends Fragment {
                         if (image != null) {
                             image.setImageURI(imageUri);
                         }
-                        CrashlyticsHelper.log(this.getClass().getSimpleName(), "onActivityResult :",
+                        CrashlyticsHelper.log(this.getClass().getSimpleName(), "onActivityResult",
                                 "imagePath : " + imagePath + " imageUri : " + imageUri);
                     }
                 } catch (NullPointerException nullException) {

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/TipsListFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/tip/TipsListFragment.java
@@ -182,7 +182,14 @@ public class TipsListFragment extends Fragment implements TipsListFilter.OnFilte
         tipProvider.retrieveTips(new DooitErrorHandler() {
             @Override
             public void onError(DooitAPIError error) {
-                Toast.makeText(getContext(), error_retrieving_tips, Toast.LENGTH_SHORT);
+                final Activity activity = getActivity();
+                if (activity != null)
+                    activity.runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            Toast.makeText(activity, error_retrieving_tips, Toast.LENGTH_LONG).show();
+                        }
+                    });
             }
         }).doAfterTerminate(new Action0() {
             @Override

--- a/app/src/main/java/org/gem/indo/dooit/views/onboarding/ProfileImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/onboarding/ProfileImageActivity.java
@@ -119,6 +119,10 @@ public class ProfileImageActivity extends ImageActivity {
                 }).doAfterTerminate(new Action0() {
             @Override
             public void call() {
+            }
+        }).doAfterTerminate(new Action0() {
+            @Override
+            public void call() {
                 dismissDialog();
             }
         }).subscribe(new Action1<Response<EmptyResponse>>() {

--- a/app/src/main/java/org/gem/indo/dooit/views/onboarding/ProfileImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/onboarding/ProfileImageActivity.java
@@ -78,7 +78,7 @@ public class ProfileImageActivity extends ImageActivity {
 
     @OnClick(R.id.activity_profile_image_profile_image)
     public void selectImage() {
-        CrashlyticsHelper.log(this.getClass().getSimpleName(), "OnClick select image : ", "Tap to change profile image (onboarding)");
+        CrashlyticsHelper.log(this.getClass().getSimpleName(), "OnClick selectImage", "Tap to change profile image (onboarding)");
         showImageChooser();
     }
 
@@ -129,7 +129,7 @@ public class ProfileImageActivity extends ImageActivity {
                     return;
 
                 try {
-                    CrashlyticsHelper.log(this.getClass().getSimpleName(), "uploadProfileImage :", String.format("User id %s: ",
+                    CrashlyticsHelper.log(this.getClass().getSimpleName(), "uploadProfileImage", String.format("User id %s: ",
                             user.getId()) + " Uri :" + localImageUri + " mediaType: " + localMediaType);
                     user.getProfile().setProfileImageUrl(localImageUri.toString());
                 } catch (NullPointerException nullException) {

--- a/app/src/main/java/org/gem/indo/dooit/views/onboarding/ProfileImageActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/onboarding/ProfileImageActivity.java
@@ -125,11 +125,13 @@ public class ProfileImageActivity extends ImageActivity {
             @Override
             public void call(Response<EmptyResponse> response) {
                 User user = persisted.getCurrentUser();
+                if (user == null)
+                    return;
 
                 try {
                     CrashlyticsHelper.log(this.getClass().getSimpleName(), "uploadProfileImage :", String.format("User id %s: ",
                             user.getId()) + " Uri :" + localImageUri + " mediaType: " + localMediaType);
-                    user.getProfile().setProfileImageUrl(getImageUri().toString());
+                    user.getProfile().setProfileImageUrl(localImageUri.toString());
                 } catch (NullPointerException nullException) {
                     CrashlyticsHelper.logException(nullException);
                 }

--- a/app/src/main/java/org/gem/indo/dooit/views/profile/ProfileActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/profile/ProfileActivity.java
@@ -210,6 +210,9 @@ public class ProfileActivity extends ImageActivity {
     @Override
     protected void onImageResult(String mediaType, Uri imageUri, String imagePath) {
         CrashlyticsHelper.log(this.getClass().getSimpleName(), "OnImageResult : ", "successful image result (settings)");
+
+        final Uri localImageUri = imageUri;
+
         // Upload image to server
         User user = persisted.getCurrentUser();
         if (user == null) {
@@ -254,7 +257,7 @@ public class ProfileActivity extends ImageActivity {
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        profileImage.setImageURI(getImageUri());
+                        profileImage.setImageURI(localImageUri);
                     }
                 });
             }

--- a/app/src/main/java/org/gem/indo/dooit/views/profile/ProfileActivity.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/profile/ProfileActivity.java
@@ -203,13 +203,13 @@ public class ProfileActivity extends ImageActivity {
 
     @OnClick(R.id.activity_profile_image)
     public void selectImage() {
-        CrashlyticsHelper.log(this.getClass().getSimpleName(), "OnClick select image : ", "Tap to change profile image (Settings)");
+        CrashlyticsHelper.log(this.getClass().getSimpleName(), "OnClick selectImage", "Tap to change profile image (Settings)");
         showImageChooser();
     }
 
     @Override
     protected void onImageResult(String mediaType, Uri imageUri, String imagePath) {
-        CrashlyticsHelper.log(this.getClass().getSimpleName(), "OnImageResult : ", "successful image result (settings)");
+        CrashlyticsHelper.log(this.getClass().getSimpleName(), "OnImageResult", "successful image result (settings)");
 
         final Uri localImageUri = imageUri;
 


### PR DESCRIPTION
Includes three fixes to problems that can affect Registration

- Forcing HTTPS connections to use TLSv1.2 ([Fabric #90](https://fabric.io/retro-rabbit/android/apps/org.gem.indo.dooit/issues/591cf3d7be077a4dccddd5b2), [Fabric #91](https://fabric.io/retro-rabbit/android/apps/org.gem.indo.dooit/issues/591e68f4be077a4dcceb91af))
- Fixed Null Pointer Exception when cancelling camera or gallery ([Fabric #54](https://fabric.io/retro-rabbit/android/apps/org.gem.indo.dooit/issues/58e5f54d0aeb16625b4e5e27))
- More aggressively recycling Bitmaps to help alleviate memory issues around manipulating images ([Fabric #53](https://fabric.io/retro-rabbit/android/apps/org.gem.indo.dooit/issues/58e5f1a80aeb16625b4e40ec), [Fabric #76](https://fabric.io/retro-rabbit/android/apps/org.gem.indo.dooit/issues/591149ecbe077a4dcc79c42d))
- Changes to multithreaded image handling to prevent changing `imageUri` and `imagePath` while background thread is working. ([Fabric #79](https://fabric.io/retro-rabbit/android/apps/org.gem.indo.dooit/issues/5911a8a3be077a4dcc7ce3c8))

### Registration process tested on following devices:

- **Samsung** SM-G930F _Android 6.0.1_
- **Samsung**  SM-G920F _Android 5.1.1_
- **Samsung** SM-G318H _Android 4.4.4_
- **Huawei** ALE-L02 _Android 5.0_
- **HTC** One X _Android 4.2.2_
- **Sony** C2105 _Andriod 4.2.2_
- **Alcatel** 4016X _Android 4.2.2_
- **LG** D855 _Android 5.0_