### PR TITLE
Goal Crash and Date Picker

### DIFF
--- a/app/src/main/java/org/gem/indo/dooit/api/interfaces/BudgetAPI.java
+++ b/app/src/main/java/org/gem/indo/dooit/api/interfaces/BudgetAPI.java
@@ -5,6 +5,7 @@ import org.gem.indo.dooit.api.requests.budget.ChangeBudgetSavings;
 import org.gem.indo.dooit.api.responses.BudgetCreateResponse;
 import org.gem.indo.dooit.api.responses.EmptyResponse;
 import org.gem.indo.dooit.models.budget.Budget;
+import org.gem.indo.dooit.models.budget.Expense;
 import org.gem.indo.dooit.models.budget.ExpenseCategory;
 
 import java.util.List;
@@ -36,6 +37,9 @@ public interface BudgetAPI {
 
     @PATCH("/api/budgets/{id}/")
     Observable<BudgetCreateResponse> updateBudget(@Path("id") long id, @Body ChangeBudgetSavings savings);
+
+    @POST("/api/budgets/{id}/expenses/")
+    Observable<BudgetCreateResponse> addExpenses(@Path("id") long id, @Body List<Expense> expenses);
 
     @DELETE("/api/expenses/{id}/")
     Observable<EmptyResponse> deleteExpense(@Path("id") long id);

--- a/app/src/main/java/org/gem/indo/dooit/api/managers/BudgetManager.java
+++ b/app/src/main/java/org/gem/indo/dooit/api/managers/BudgetManager.java
@@ -9,6 +9,7 @@ import org.gem.indo.dooit.api.requests.budget.ChangeBudgetSavings;
 import org.gem.indo.dooit.api.responses.BudgetCreateResponse;
 import org.gem.indo.dooit.api.responses.EmptyResponse;
 import org.gem.indo.dooit.models.budget.Budget;
+import org.gem.indo.dooit.models.budget.Expense;
 import org.gem.indo.dooit.models.budget.ExpenseCategory;
 
 import java.util.List;
@@ -47,6 +48,10 @@ public class BudgetManager extends DooitManager {
 
     public Observable<BudgetCreateResponse> updateBudgetSavings(long budgetId, double savings, DooitErrorHandler errorHandler) {
         return useNetwork(budgetAPI.updateBudget(budgetId, new ChangeBudgetSavings(savings)), errorHandler);
+    }
+
+    public Observable<BudgetCreateResponse> addExpenses(long budgetId, List<Expense> expenses, DooitErrorHandler errorHandler) {
+        return useNetwork(budgetAPI.addExpenses(budgetId, expenses), errorHandler);
     }
 
     public Observable<EmptyResponse> deleteExpense(long expenseId, DooitErrorHandler errorHandler) {

--- a/app/src/main/java/org/gem/indo/dooit/controllers/budget/BudgetBotController.java
+++ b/app/src/main/java/org/gem/indo/dooit/controllers/budget/BudgetBotController.java
@@ -13,8 +13,8 @@ import org.gem.indo.dooit.helpers.bot.BotRunner;
 import org.gem.indo.dooit.helpers.bot.param.ParamArg;
 import org.gem.indo.dooit.helpers.bot.param.ParamMatch;
 import org.gem.indo.dooit.helpers.bot.param.ParamParser;
-import org.gem.indo.dooit.models.Badge;
 import org.gem.indo.dooit.helpers.crashlytics.CrashlyticsHelper;
+import org.gem.indo.dooit.models.Badge;
 import org.gem.indo.dooit.models.bot.Answer;
 import org.gem.indo.dooit.models.bot.BaseBotModel;
 import org.gem.indo.dooit.models.bot.Node;
@@ -84,7 +84,7 @@ public abstract class BudgetBotController extends DooitBotController {
         activity.setTipQuery(activity.getString(R.string.budget_create_qry_tip_income));
     }
 
-    private void tipQueryBudget(){
+    private void tipQueryBudget() {
         if (activity == null)
             return;
         activity.setTipQuery(activity.getString(R.string.budget_create_qry_tip_budget));
@@ -174,10 +174,10 @@ public abstract class BudgetBotController extends DooitBotController {
 
     private void doAddBadge() {
         List<Badge> badges = persisted.loadNewBudgetBadges();
-        if(badges.size() > 0) {
+        if (badges.size() > 0) {
             for (Badge badge : badges)
                 botRunner.queueNode(nodeFromBadge(badge));
-        }else{
+        } else {
             Node node = new Node();
             node.setName("save_Conversation_Node");
             node.setType(BotMessageType.DUMMY);

--- a/app/src/main/java/org/gem/indo/dooit/controllers/budget/BudgetCreateController.java
+++ b/app/src/main/java/org/gem/indo/dooit/controllers/budget/BudgetCreateController.java
@@ -7,7 +7,6 @@ import org.gem.indo.dooit.DooitApplication;
 import org.gem.indo.dooit.api.DooitAPIError;
 import org.gem.indo.dooit.api.DooitErrorHandler;
 import org.gem.indo.dooit.api.managers.BudgetManager;
-import org.gem.indo.dooit.api.managers.GoalManager;
 import org.gem.indo.dooit.api.responses.BudgetCreateResponse;
 import org.gem.indo.dooit.dao.budget.BudgetDAO;
 import org.gem.indo.dooit.dao.budget.ExpenseCategoryBotDAO;
@@ -288,9 +287,9 @@ public class BudgetCreateController extends BudgetBotController {
         node.setType(BotMessageType.DUMMY);
 
         List<Goal> goals = persisted.loadConvoGoals(botType);
-        if(goals.size() > 0){
+        if (goals.size() > 0) {
             node.setAutoNext("budget_create_q_final_positive_has_goals");
-        }else{
+        } else {
             node.setAutoNext("budget_create_q_final_positive_no_goals");
         }
         botRunner.queueNode(node);

--- a/app/src/main/java/org/gem/indo/dooit/controllers/budget/BudgetCreateController.java
+++ b/app/src/main/java/org/gem/indo/dooit/controllers/budget/BudgetCreateController.java
@@ -251,7 +251,7 @@ public class BudgetCreateController extends BudgetBotController {
     }
 
     private void clearExpenses() {
-        new ExpenseCategoryBotDAO().clear(botType);
+        ExpenseCategoryBotDAO.clear(botType);
     }
 
     private void branchBudgetFinal(Map<String, Answer> answerLog) {

--- a/app/src/main/java/org/gem/indo/dooit/controllers/goal/GoalAddController.java
+++ b/app/src/main/java/org/gem/indo/dooit/controllers/goal/GoalAddController.java
@@ -60,9 +60,15 @@ public class GoalAddController extends GoalBotController {
     @Inject
     Persisted persisted;
 
-    public GoalAddController(Activity activity, BotRunner botRunner, Budget budget, List<GoalPrototype> prototypes,
-                             Goal goal, BaseChallenge challenge, Tip tip) {
-        super(activity, botRunner, BotType.GOAL_ADD, prototypes, goal, challenge, tip);
+    public GoalAddController(Activity activity,
+                             BotRunner botRunner,
+                             BotType botType, // This controller can be either DEFAULT or GOAL_ADD
+                             Budget budget,
+                             List<GoalPrototype> prototypes,
+                             Goal goal,
+                             BaseChallenge challenge,
+                             Tip tip) {
+        super(activity, botRunner, botType, prototypes, goal, challenge, tip);
         ((DooitApplication) activity.getApplication()).component.inject(this);
         if (this.goal == null)
             this.goal = new Goal();

--- a/app/src/main/java/org/gem/indo/dooit/controllers/goal/GoalAddController.java
+++ b/app/src/main/java/org/gem/indo/dooit/controllers/goal/GoalAddController.java
@@ -261,10 +261,10 @@ public class GoalAddController extends GoalBotController {
 
                         //the path is now extracted form the Answer.values map as explained int the comment above "final String path = MediaUriHelper.getPath(context, uri);"
                         String path = null;
-                        if(answerLogTemp.containsKey("goal_add_a_goal_image")){
+                        if (answerLogTemp.containsKey("goal_add_a_goal_image")) {
                             Answer imageAnswer = answerLogTemp.get("goal_add_a_goal_image");
                             path = imageAnswer.values.getString(Answer.IMAGEPATH);
-                        }else{
+                        } else {
                             path = goal.getPrototype().getImageUrl();
                         }
 

--- a/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/Persisted.java
@@ -34,7 +34,6 @@ import org.gem.indo.dooit.models.goal.Goal;
 import org.gem.indo.dooit.models.goal.GoalPrototype;
 import org.gem.indo.dooit.models.survey.CoachSurvey;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -555,7 +554,7 @@ public class Persisted {
      */
 
     public void saveNewBudgetBadges(List<Badge> newBages) {
-            dooitSharedPreferences.setComplex(NEW_BUDGET_BADGES, newBages.toArray());
+        dooitSharedPreferences.setComplex(NEW_BUDGET_BADGES, newBages.toArray());
     }
 
     public void clearNewBudgetBadges() {
@@ -563,10 +562,10 @@ public class Persisted {
     }
 
     public List<Badge> loadNewBudgetBadges() {
-        Badge [] arrayBadges = dooitSharedPreferences.getComplex(NEW_BUDGET_BADGES, Badge[].class);
-        if(arrayBadges != null){
+        Badge[] arrayBadges = dooitSharedPreferences.getComplex(NEW_BUDGET_BADGES, Badge[].class);
+        if (arrayBadges != null) {
             return new ArrayList<Badge>(Arrays.asList(arrayBadges));
-        }else {
+        } else {
             return new ArrayList<Badge>();
         }
 

--- a/app/src/main/java/org/gem/indo/dooit/helpers/ValueMap.java
+++ b/app/src/main/java/org/gem/indo/dooit/helpers/ValueMap.java
@@ -1,5 +1,6 @@
 package org.gem.indo.dooit.helpers;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -113,7 +114,17 @@ public class ValueMap {
     }
 
     public String[] getStringArray(String key) {
-        return (String[]) map.get(key);
+        Object value = map.get(key);
+        // Deserialized as ArrayList after badge has been added. Avoids class cast exception
+        if (value instanceof ArrayList) {
+            ArrayList lst = (ArrayList) value;
+            String[] arr = new String[lst.size()];
+            return (String[]) lst.toArray(arr);
+        } else if (value instanceof String[]) {
+            return (String[]) value;
+        } else {
+            return new String[0];
+        }
     }
 
     /******************

--- a/app/src/main/java/org/gem/indo/dooit/models/goal/Goal.java
+++ b/app/src/main/java/org/gem/indo/dooit/models/goal/Goal.java
@@ -319,6 +319,8 @@ public class Goal {
     }
 
     public int getRemainderDays() {
+        if (startDate == null || endDate == null)
+            return 0;
         return WeekCalc.remainder(startDate.toDate(), endDate.toDate());
     }
 

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/BotFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/BotFragment.java
@@ -544,7 +544,7 @@ public class BotFragment extends MainFragment implements HashtagView.TagsClickLi
                 budget = new BudgetDAO().findFirst();
                 if (budget == null)
                     throw new NullPointerException("Budget Edit conversation started with no budget in db");
-                return new BudgetEditController(getActivity(), this, budget);
+                return new BudgetEditController(getActivity(), this, budget, persisted.loadNewBudgetBadges());
             }
             default:
                 return null;

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/BotFragment.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/BotFragment.java
@@ -498,6 +498,7 @@ public class BotFragment extends MainFragment implements HashtagView.TagsClickLi
             case GOAL_ADD:
                 budget = new BudgetDAO().findFirst();
                 return new GoalAddController(getActivity(), this,
+                        botType,
                         budget,
                         persisted.loadGoalProtos(),
                         persisted.loadConvoGoal(botType),

--- a/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerInlineDateEditViewHolder.java
+++ b/app/src/main/java/org/gem/indo/dooit/views/main/fragments/bot/viewholders/AnswerInlineDateEditViewHolder.java
@@ -1,5 +1,7 @@
 package org.gem.indo.dooit.views.main.fragments.bot.viewholders;
 
+import android.content.DialogInterface;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.text.InputType;
 import android.view.KeyEvent;
@@ -46,6 +48,8 @@ public class AnswerInlineDateEditViewHolder extends BaseBotViewHolder<Answer> {
         this.botAdapter = botAdapter;
         this.tagsClickListener = tagsClickListener;
         ButterKnife.bind(this, itemView);
+
+        editText.setBackground(ContextCompat.getDrawable(itemView.getContext(), R.drawable.ic_d_answer_dialogue_bkg_blue));
     }
 
     @Override
@@ -54,7 +58,10 @@ public class AnswerInlineDateEditViewHolder extends BaseBotViewHolder<Answer> {
         editText.setHint(dataModel.getInlineEditHint(getContext()));
         editText.setImeActionLabel("Done", KeyEvent.KEYCODE_ENTER);
         editText.setInputType(InputType.TYPE_DATETIME_VARIATION_DATE);
-        editText.setEnabled(false);
+        // The combination of these two flags will allow the edit text to be clicked, but not accept
+        // any kayboard input.
+        editText.setEnabled(true);
+        editText.setFocusable(false);
         editText.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -77,7 +84,7 @@ public class AnswerInlineDateEditViewHolder extends BaseBotViewHolder<Answer> {
                         inputAnswer.setValue(
                                 (DateFormat.getInstance().format(cal.getTime()))
                                         .substring(0, (DateFormat.getInstance().format(endDate)).indexOf(" "))
-                                + " - " + weekMsg);
+                                        + " - " + weekMsg);
                         //inputAnswer.setValue(DateFormat.getInstance().format(cal.getTime()) + " - " + Utils.weekDiff(cal.getTime().getTime(), Utils.ROUNDWEEK.UP) + " " + weeks);
                         inputAnswer.values.put("date", Utils.formatDate(cal.getTime()));
                         inputAnswer.setText(null);
@@ -87,6 +94,13 @@ public class AnswerInlineDateEditViewHolder extends BaseBotViewHolder<Answer> {
                         inputAnswer.setType(BotMessageType.getValueOf(dataModel.getTypeOnFinish()));
                         tagsClickListener.onItemClicked(inputAnswer);
                         CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate", "(dateEdit) New date: " + inputAnswer.getValue());
+                    }
+                });
+                dateFragment.setOnDismissListener(new DialogInterface.OnDismissListener() {
+                    @Override
+                    public void onDismiss(DialogInterface dialog) {
+                        // Do nothing on dismiss
+                        CrashlyticsHelper.log(this.getClass().getSimpleName(), "populate", "Date Picker Dismissed");
                     }
                 });
             }

--- a/app/src/main/res/layout/item_view_bot_inline_edit.xml
+++ b/app/src/main/res/layout/item_view_bot_inline_edit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tem_view_bot_inline_edit"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"


### PR DESCRIPTION
This PR fixes the following:

- The conversation getting stuck when the Date Picker is cancelled. The chat bubble is now clickable and will reopen the date picker.
- Crash where the Goal's dates were `null` at the end of the conversation. The cause was the `GoalAddController` saving the Goal under `GOAL_ADD` and the Bot reloading it as type `DEFAULT`. The whole Goal is loaded is newly instantiated. ([Fabric #88](https://fabric.io/retro-rabbit/android/apps/org.gem.indo.dooit/issues/5917e9f0be077a4dccb34b7e?time=last-ninety-days))
- Class Cast exception when navigating away from a Budget badge [Fabric #55](https://www.fabric.io/retro-rabbit/android/apps/org.gem.indo.dooit/issues/58e600270aeb16625b4eb7bd)
- Fix problem with Budget Edit Badge not appearing