### PR TITLE
Release 1.2.7

### DIFF
--- a/app/release-notes.txt
+++ b/app/release-notes.txt
@@ -1,7 +1,7 @@
 
-1.2.6
+1.2.7
 
-- Forcing HTTPS connections to use TLSv1.2
-- Fixed Null Pointer Exception when cancelling camera or gallery
-- More aggressively recycling Bitmaps to help alleviate memory issues around manipulating images
-- Added Endline Survey
+- Fixed issue preventing goal picker from being reopened when closed during goal converstation.
+- Fixed crash where goal date can be empty at the end of a conversation
+- Fixed exception when navigating away from a budget badge
+- Fixed issue with Budget Edit Badge not appearing

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ org.gradle.jvmargs=-Xmx4608M
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-version=010206
-versionName=1.2.6
+version=010207
+versionName=1.2.7
 repositoryVersion=25.0.2
 minSdkVersion=17
 compileSdkVersion=24


### PR DESCRIPTION
- Fixed issue preventing goal picker from being reopened when closed during goal converstation.
- Fixed crash where goal date can be empty at the end of a conversation
- Fixed exception when navigating away from a budget badge
- Fixed issue with Budget Edit Badge not appearing